### PR TITLE
78 implementation   lsa for heredoc

### DIFF
--- a/src/include/libms.h
+++ b/src/include/libms.h
@@ -58,6 +58,7 @@ void *ms_identify(void *arg);
 void ms_noop_del(void *arg);
 
 void ms_lstappend_tail(t_list **lst, void *content, void (*fr)(void *));
+void			ms_lst_print(t_list *lst, void (*print)(void *));
 
 // environment variable
 char			*ms_getenv(const char *name);

--- a/src/include/libms.h
+++ b/src/include/libms.h
@@ -44,7 +44,7 @@ bool			ms_is_dir(const char *path);
 char			*ms_to_abs_path(const char *path);
 char			*ms_normalize_path(const char *path);
 char			*ms_get_full_path(const char *basedir, const char *path);
-char			*ms_replace_joined_str(char **left, char *right);
+char			*ms_replace_joined_str(char **left, const char *right);
 char			*ms_tilde_expansion(const char *path);
 int				ms_trim_end_newline(char *str);
 

--- a/src/include/semantic_analyze.h
+++ b/src/include/semantic_analyze.h
@@ -14,4 +14,12 @@ t_lsa_pipeline *ms_lsa_pipeline(t_syntax_node *pipeline_node);
 t_lsa_list *ms_lsa_list(t_syntax_node *list_node);
 t_lsa_list **ms_lsa_lists(t_syntax_node *lists_node);
 
+int ms_set_readnodestream(t_syntax_node *node);
+void ms_unset_readnodestream(void);
+t_syntax_node *ms_read_node(void);
+t_list	*ms_get_next_line_node(void);
+char *ms_word_list_to_delimiter_string(t_lsa_word_list *word_list);
+int	ms_lsa_set_heredoc(t_lsa_redirection *lsa_redirection, t_syntax_node *delimiter_node);
+bool	ms_compare_heredoc_input(const char *input, const char *delimiter);
+
 #endif

--- a/src/include/syntax_analyze.h
+++ b/src/include/syntax_analyze.h
@@ -9,6 +9,11 @@ t_syntax_node *ms_syntax_analyze(t_token **tokens);
 t_syntax_node *ms_syntax_node_create(t_syntax_type type);
 void ms_syntax_node_destroy(t_syntax_node *node);
 void ms_syntax_node_destroy_wrapper(void *node);
+void	ms_syntax_node_print(t_syntax_node *node);
+t_syntax_node	*ms_syntax_node_find_child(
+					t_syntax_node *node, t_syntax_type type);
+t_syntax_node	*ms_syntax_node_get_child(
+					t_syntax_node *node, t_syntax_type type);
 
 t_syntax_node *ms_syntax_node_set_of_children(t_syntax_node *node, t_syntax_node_list **child_lst);
 

--- a/src/libms/ms_lst_print.c
+++ b/src/libms/ms_lst_print.c
@@ -1,0 +1,22 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_lst_print.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/29 11:45:17 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/01/29 11:45:31 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+void	ms_lst_print(t_list *lst, void (*print)(void *))
+{
+	while (lst != NULL)
+	{
+		print(lst->content);
+		lst = lst->next;
+	}
+}

--- a/src/libms/ms_replace_joined_str.c
+++ b/src/libms/ms_replace_joined_str.c
@@ -19,7 +19,7 @@
  * @param right right string.
  * @return replaced string.
  */
-char	*ms_replace_joined_str(char **left, char *right)
+char	*ms_replace_joined_str(char **left, const char *right)
 {
 	char	*tmp;
 

--- a/src/semantic_analyze/heredoc/ms_compare_heredoc_input.c
+++ b/src/semantic_analyze/heredoc/ms_compare_heredoc_input.c
@@ -1,0 +1,32 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_compare_heredoc_input.c                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/29 12:26:06 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/01/29 12:26:20 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+#include <stdbool.h>
+
+bool	ms_compare_heredoc_input(const char *input, const char *delimiter)
+{
+	size_t	input_len;
+	size_t	delimiter_len;
+
+	input_len = ft_strlen(input);
+	delimiter_len = ft_strlen(delimiter);
+	if (input_len > 0 && input[input_len - 1] == '\n')
+		input_len--;
+	if (delimiter_len > 0 && delimiter[delimiter_len - 1] == '\n')
+		delimiter_len--;
+	if (input_len != delimiter_len)
+		return (false);
+	if (ft_strncmp(input, delimiter, input_len) != 0)
+		return (false);
+	return (true);
+}

--- a/src/semantic_analyze/heredoc/ms_get_next_line_node.c
+++ b/src/semantic_analyze/heredoc/ms_get_next_line_node.c
@@ -1,0 +1,36 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_get_next_line_node.c                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/29 10:58:21 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/01/29 10:58:55 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "syntax_analyze.h"
+#include "libft.h"
+#include "semantic_analyze.h"
+
+t_list	*ms_get_next_line_node(void)
+{
+	t_syntax_node	*node;
+	t_list			*lst;
+	t_list			*newlst;
+
+	lst = NULL;
+	node = ms_read_node();
+	while (node != NULL)
+	{
+		newlst = ft_lstnew(node);
+		if (newlst == NULL)
+			break ;
+		ft_lstadd_back(&lst, newlst);
+		if (ft_strcmp(node->token->token, "\n") == 0)
+			break ;
+		node = ms_read_node();
+	}
+	return (lst);
+}

--- a/src/semantic_analyze/heredoc/ms_set_readnodestream.c
+++ b/src/semantic_analyze/heredoc/ms_set_readnodestream.c
@@ -1,0 +1,36 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_set_readnodestream.c                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/23 04:46:51 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/01/28 06:22:57 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "syntax_analyze.h"
+
+static int				g_pos = 0;
+static t_syntax_node	**g_stream = NULL;
+
+void	ms_set_readnodestream(t_syntax_node *node)
+{
+	g_stream = node->children;
+	g_pos = 0;
+	return ;
+}
+
+void	ms_unset_readnodestream(void)
+{
+	g_pos = 0;
+	g_stream = NULL;
+}
+
+t_syntax_node	*ms_read_node(void)
+{
+	if (g_stream == NULL)
+		return (NULL);
+	return (g_stream[g_pos++]);
+}

--- a/src/semantic_analyze/heredoc/ms_word_list_to_delimiter_string.c
+++ b/src/semantic_analyze/heredoc/ms_word_list_to_delimiter_string.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/28 07:31:33 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/01/29 12:59:40 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/01/29 13:36:15 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,7 +55,8 @@ char	*ms_word_list_to_delimiter_string(t_lsa_word_list *word_list)
 /**
  * @param right expected type: SYNGLE_QUOTED_WORD or DOUBLE_QUOTED_WORD
  */
-int	ms_replace_joined_str_quoted_word(char **left, const t_syntax_node *right)
+static int	ms_replace_joined_str_quoted_word(
+				char **left, const t_syntax_node *right)
 {
 	char			*quoted_word;
 	int				pos;

--- a/src/semantic_analyze/heredoc/ms_word_list_to_delimiter_string.c
+++ b/src/semantic_analyze/heredoc/ms_word_list_to_delimiter_string.c
@@ -6,10 +6,9 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/28 07:31:33 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/01/28 08:15:13 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/01/29 12:59:40 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
-
 
 #include "syntax_analyze.h"
 #include "semantic_analyze.h"

--- a/src/semantic_analyze/heredoc/ms_word_list_to_delimiter_string.c
+++ b/src/semantic_analyze/heredoc/ms_word_list_to_delimiter_string.c
@@ -1,0 +1,83 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_word_list_to_delimiter_string.c                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/28 07:31:33 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/01/28 08:15:13 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+
+#include "syntax_analyze.h"
+#include "semantic_analyze.h"
+#include "libft.h"
+#include "libms.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static int	ms_replace_joined_str_quoted_word(
+				char **left, const t_syntax_node *right);
+
+/**
+ * @brief デリミタワードリストを文字列に変換する
+ */
+char	*ms_word_list_to_delimiter_string(t_lsa_word_list *word_list)
+{
+	char			*delimiter;
+	t_syntax_node	*wl_node;
+	t_syntax_node	*inner_node;
+	int				pos;
+
+	delimiter = ft_strdup("");
+	if (delimiter == NULL)
+		return (NULL);
+	wl_node = word_list->word_list;
+	pos = 0;
+	while (wl_node->children[pos] != NULL)
+	{
+		inner_node = wl_node->children[pos];
+		if (inner_node->type == SY_DOUBLE_QUOTED_WORD
+			|| inner_node->type == SY_SINGLE_QUOTED_WORD)
+			ms_replace_joined_str_quoted_word(&delimiter, inner_node);
+		else
+		{
+			if (ms_replace_joined_str(
+					&delimiter, inner_node->token->token) == NULL)
+				return (free(delimiter), NULL);
+		}
+		pos++;
+	}
+	return (delimiter);
+}
+
+/**
+ * @param right expected type: SYNGLE_QUOTED_WORD or DOUBLE_QUOTED_WORD
+ */
+int	ms_replace_joined_str_quoted_word(char **left, const t_syntax_node *right)
+{
+	char			*quoted_word;
+	int				pos;
+	t_syntax_node	*all_node;
+
+	quoted_word = ft_strdup("");
+	if (quoted_word == NULL)
+		return (-1);
+	pos = 0;
+	if (! (right->children[pos]->type == SY_DOUBLE_QUOTE
+			|| right->children[pos]->type == SY_SINGLE_QUOTE))
+		return (free(quoted_word), -1);
+	pos++;
+	while (right->children[pos] != NULL && right->children[pos]->type == SY_ALL)
+	{
+		all_node = right->children[pos];
+		if (ms_replace_joined_str(&quoted_word, all_node->token->token) == NULL)
+			return (free(quoted_word), -1);
+		pos++;
+	}
+	free(*left);
+	*left = quoted_word;
+	return (0);
+}

--- a/src/semantic_analyze/lsa_destroy/ms_lsa_redirection_destroy.c
+++ b/src/semantic_analyze/lsa_destroy/ms_lsa_redirection_destroy.c
@@ -3,15 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   ms_lsa_redirection_destroy.c                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rnakatan <rnakatan@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 09:13:08 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/01/22 09:13:09 by rnakatan         ###   ########.fr       */
+/*   Updated: 2025/01/29 12:05:19 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "semantic_analyze.h"
 #include "semantic_analyze_internal.h"
+#include "syntax_analyze.h"
+#include "libms.h"
 #include <stdlib.h>
 
 /*notes
@@ -25,7 +27,8 @@ void	ms_lsa_redirection_destroy(t_lsa_redirection *redirection)
 		ms_lsa_wordlist_destroy(redirection->filename);
 	if (redirection->delimiter != NULL)
 		ms_lsa_wordlist_destroy(redirection->delimiter);
-	// if (redirection->heredoc_input != NULL)
-	// 	ms_syntax_node_destroy(redirection->heredoc_input);
+	if (redirection->heredoc_input != NULL)
+		ms_destroy_ntp2((void **)redirection->heredoc_input,
+			(void (*)(void *))ms_syntax_node_destroy);
 	free(redirection);
 }

--- a/src/semantic_analyze/lsa_destroy/ms_lsa_redirection_destroy.c
+++ b/src/semantic_analyze/lsa_destroy/ms_lsa_redirection_destroy.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 09:13:08 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/01/29 12:05:19 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/01/29 13:22:59 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,6 @@ void	ms_lsa_redirection_destroy(t_lsa_redirection *redirection)
 	if (redirection->delimiter != NULL)
 		ms_lsa_wordlist_destroy(redirection->delimiter);
 	if (redirection->heredoc_input != NULL)
-		ms_destroy_ntp2((void **)redirection->heredoc_input,
-			(void (*)(void *))ms_syntax_node_destroy);
+		free(redirection->heredoc_input);
 	free(redirection);
 }

--- a/src/semantic_analyze/ms_lsa_redirection.c
+++ b/src/semantic_analyze/ms_lsa_redirection.c
@@ -3,13 +3,14 @@
 /*                                                        :::      ::::::::   */
 /*   ms_lsa_redirection.c                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rnakatan <rnakatan@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 09:14:07 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/01/22 09:15:35 by rnakatan         ###   ########.fr       */
+/*   Updated: 2025/01/29 12:10:19 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "semantic_analyze_internal.h"
 #include "semantic_analyze.h"
 #include <stdlib.h>
 
@@ -20,12 +21,17 @@ t_lsa_redirection	*ms_lsa_redirection(const t_syntax_node *redirection_node)
 {
 	t_lsa_redirection_type	type;
 	t_lsa_redirection		*lsa_redirection;
+	int						pos;
 
 	type = ms_lsa_redirection_type(redirection_node->children[0]->token->token);
 	lsa_redirection = ms_lsa_redirection_create(type);
 	if (lsa_redirection->type == LSA_RD_HEREDOC)
 	{
-		// get of heredoc_input
+		pos = 1;
+		if (redirection_node->children[pos]->type == SY_BLANK)
+			pos++;
+		if (ms_lsa_set_heredoc(lsa_redirection, redirection_node->children[pos]) != 0)
+			return (ms_lsa_redirection_destroy(lsa_redirection), NULL);
 	}
 	else
 	{
@@ -34,7 +40,7 @@ t_lsa_redirection	*ms_lsa_redirection(const t_syntax_node *redirection_node)
 		else
 			lsa_redirection->filename = ms_lsa_word_list(redirection_node->children[2]);
 		if (lsa_redirection->filename == NULL)
-			return (free(lsa_redirection), NULL);
+			return (free(lsa_redirection), NULL); // TODO: i think we should use ms_lsa_redirection_destroy
 	}
 	return (lsa_redirection);
 }

--- a/src/semantic_analyze/ms_lsa_redirection.c
+++ b/src/semantic_analyze/ms_lsa_redirection.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 09:14:07 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/01/29 12:10:19 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/01/29 12:58:03 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,7 +40,7 @@ t_lsa_redirection	*ms_lsa_redirection(const t_syntax_node *redirection_node)
 		else
 			lsa_redirection->filename = ms_lsa_word_list(redirection_node->children[2]);
 		if (lsa_redirection->filename == NULL)
-			return (free(lsa_redirection), NULL); // TODO: i think we should use ms_lsa_redirection_destroy
+			return (free(lsa_redirection), NULL);
 	}
 	return (lsa_redirection);
 }

--- a/src/semantic_analyze/ms_lsa_set_heredoc.c
+++ b/src/semantic_analyze/ms_lsa_set_heredoc.c
@@ -1,0 +1,92 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_lsa_set_heredoc.c                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/23 05:22:50 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/01/29 12:53:45 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "semantic_analyze.h"
+#include "semantic_analyze_internal.h"
+#include "syntax_analyze.h"
+#include "libms.h"
+#include "libft.h"
+#include <stdlib.h>
+
+int	ms_lsa_set_heredoc_input(t_lsa_redirection *lsa_redirection, const char *delimiter);
+t_list	*ms_get_next_line_node(void);
+char	*ms_lst_node_to_string(t_list *lst);
+bool	ms_compare_heredoc_input(const char *input, const char *delimiter);
+
+int	ms_lsa_set_heredoc(t_lsa_redirection *lsa_redirection, t_syntax_node *delimiter_node)
+{
+	char	*delimiter;
+
+	lsa_redirection->delimiter = ms_lsa_word_list(delimiter_node);
+	if (lsa_redirection->delimiter == NULL)
+		return (-1);
+	delimiter = ms_word_list_to_delimiter_string(lsa_redirection->delimiter);
+	if (delimiter != NULL)
+	{
+		if (ms_lsa_set_heredoc_input(lsa_redirection, delimiter) == 0)
+			return (free(delimiter), 0);
+		free(delimiter);
+	}
+	ms_lsa_wordlist_destroy(lsa_redirection->delimiter);
+	return (-1);
+}
+
+int	ms_lsa_set_heredoc_input(t_lsa_redirection *lsa_redirection, const char *delimiter)
+{
+	t_list	*heredoc_lst;
+	t_list	*line_lst;
+	char	*line_str;
+	int		result;
+
+	heredoc_lst = NULL;
+	lsa_redirection->heredoc_input = NULL;
+	while (1)
+	{
+		line_lst = ms_get_next_line_node();
+		if (line_lst == NULL)
+			break ;
+		line_str = ms_lst_node_to_string(line_lst);
+		if (line_str == NULL)
+			break ;
+		result = ms_compare_heredoc_input(line_str, delimiter);
+		free(line_str);
+		if (result)
+		{
+			ft_lstclear(&line_lst, ms_noop_del);
+			break ;
+		}
+		ft_lstadd_back(&heredoc_lst, line_lst);
+		line_lst = NULL;
+	}
+	lsa_redirection->heredoc_input = (t_syntax_node **)ms_lst_to_ntp(&heredoc_lst, ms_identify, ms_noop_del);
+	if (lsa_redirection->heredoc_input == NULL)
+		return (ft_lstclear(&heredoc_lst, ms_noop_del), -1);
+	return (0);
+}
+
+char	*ms_lst_node_to_string(t_list *lst)
+{
+	char			*output;
+	t_syntax_node	*node;
+
+	output = ft_strdup("");
+	if (output == NULL)
+		return (NULL);
+	while (lst != NULL)
+	{
+		node = lst->content;
+		if (ms_replace_joined_str(&output, node->token->token) == NULL)
+			return (free(output), NULL);
+		lst = lst->next;
+	}
+	return (output);
+}

--- a/src/semantic_analyze/ms_lsa_set_heredoc.c
+++ b/src/semantic_analyze/ms_lsa_set_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/23 05:22:50 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/01/29 12:53:45 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/01/29 13:13:15 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,12 +17,13 @@
 #include "libft.h"
 #include <stdlib.h>
 
-int	ms_lsa_set_heredoc_input(t_lsa_redirection *lsa_redirection, const char *delimiter);
-t_list	*ms_get_next_line_node(void);
-char	*ms_lst_node_to_string(t_list *lst);
-bool	ms_compare_heredoc_input(const char *input, const char *delimiter);
+static int		ms_lsa_set_heredoc_input(
+					t_lsa_redirection *lsa_redirection, const char *delimiter);
+static t_list	*ms_lsa_get_heredoc_input_lst(const char *delimiter);
+static char		*ms_lst_node_to_string(t_list *lst);
 
-int	ms_lsa_set_heredoc(t_lsa_redirection *lsa_redirection, t_syntax_node *delimiter_node)
+int	ms_lsa_set_heredoc(
+		t_lsa_redirection *lsa_redirection, t_syntax_node *delimiter_node)
 {
 	char	*delimiter;
 
@@ -40,7 +41,21 @@ int	ms_lsa_set_heredoc(t_lsa_redirection *lsa_redirection, t_syntax_node *delimi
 	return (-1);
 }
 
-int	ms_lsa_set_heredoc_input(t_lsa_redirection *lsa_redirection, const char *delimiter)
+int	ms_lsa_set_heredoc_input(
+		t_lsa_redirection *lsa_redirection, const char *delimiter)
+{
+	t_list			*heredoc_lst;
+	t_syntax_node	**heredoc_input;
+
+	heredoc_lst = ms_lsa_get_heredoc_input_lst(delimiter);
+	heredoc_input = ms_lst_to_ntp(&heredoc_lst, ms_identify, ms_noop_del);
+	lsa_redirection->heredoc_input = heredoc_input;
+	if (lsa_redirection->heredoc_input == NULL)
+		return (ft_lstclear(&heredoc_lst, ms_noop_del), -1);
+	return (0);
+}
+
+t_list	*ms_lsa_get_heredoc_input_lst(const char *delimiter)
 {
 	t_list	*heredoc_lst;
 	t_list	*line_lst;
@@ -48,7 +63,6 @@ int	ms_lsa_set_heredoc_input(t_lsa_redirection *lsa_redirection, const char *del
 	int		result;
 
 	heredoc_lst = NULL;
-	lsa_redirection->heredoc_input = NULL;
 	while (1)
 	{
 		line_lst = ms_get_next_line_node();
@@ -67,10 +81,7 @@ int	ms_lsa_set_heredoc_input(t_lsa_redirection *lsa_redirection, const char *del
 		ft_lstadd_back(&heredoc_lst, line_lst);
 		line_lst = NULL;
 	}
-	lsa_redirection->heredoc_input = (t_syntax_node **)ms_lst_to_ntp(&heredoc_lst, ms_identify, ms_noop_del);
-	if (lsa_redirection->heredoc_input == NULL)
-		return (ft_lstclear(&heredoc_lst, ms_noop_del), -1);
-	return (0);
+	return (heredoc_lst);
 }
 
 char	*ms_lst_node_to_string(t_list *lst)

--- a/src/semantic_analyze/ms_lsa_set_heredoc.c
+++ b/src/semantic_analyze/ms_lsa_set_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/23 05:22:50 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/01/29 13:13:15 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/01/29 13:35:52 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,7 @@ int	ms_lsa_set_heredoc(
 	return (-1);
 }
 
-int	ms_lsa_set_heredoc_input(
+static int	ms_lsa_set_heredoc_input(
 		t_lsa_redirection *lsa_redirection, const char *delimiter)
 {
 	t_list			*heredoc_lst;
@@ -55,7 +55,7 @@ int	ms_lsa_set_heredoc_input(
 	return (0);
 }
 
-t_list	*ms_lsa_get_heredoc_input_lst(const char *delimiter)
+static t_list	*ms_lsa_get_heredoc_input_lst(const char *delimiter)
 {
 	t_list	*heredoc_lst;
 	t_list	*line_lst;
@@ -84,7 +84,7 @@ t_list	*ms_lsa_get_heredoc_input_lst(const char *delimiter)
 	return (heredoc_lst);
 }
 
-char	*ms_lst_node_to_string(t_list *lst)
+static char	*ms_lst_node_to_string(t_list *lst)
 {
 	char			*output;
 	t_syntax_node	*node;

--- a/src/semantic_analyze/semantic_analyze.c
+++ b/src/semantic_analyze/semantic_analyze.c
@@ -3,14 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   semantic_analyze.c                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rnakatan <rnakatan@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 09:14:17 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/01/22 09:14:17 by rnakatan         ###   ########.fr       */
+/*   Updated: 2025/01/29 10:41:12 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "semantic_analyze.h"
+#include "syntax_analyze.h"
 #include <stdlib.h>
 
 /* notes
@@ -18,13 +19,18 @@
  */
 t_lsa	*semantic_analyze(t_syntax_node *node)
 {
-	t_lsa		*lsa;
-	t_lsa_list	**lists;
+	t_lsa			*lsa;
+	t_lsa_list		**lists;
+	t_syntax_node	*user_input_node;
 
 	lsa = malloc(sizeof(t_lsa));
 	if (lsa == NULL)
 		return (NULL);
+	user_input_node = ms_syntax_node_get_child(node, SY_USER_INPUT);
+	if (user_input_node != NULL)
+		ms_set_readnodestream(user_input_node);
 	lists = ms_lsa_lists(node->children[0]);
+	ms_unset_readnodestream();
 	if (lists == NULL)
 		return (NULL);
 	// heredoc用の処理も必要

--- a/src/semantic_analyze/semantic_analyze.c
+++ b/src/semantic_analyze/semantic_analyze.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 09:14:17 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/01/29 10:41:12 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/01/29 13:15:42 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,6 @@ t_lsa	*semantic_analyze(t_syntax_node *node)
 	ms_unset_readnodestream();
 	if (lists == NULL)
 		return (NULL);
-	// heredoc用の処理も必要
 	lsa->lists = lists;
 	return (lsa);
 }

--- a/src/syntax_analyze/ms_syntax_node_find_child.c
+++ b/src/syntax_analyze/ms_syntax_node_find_child.c
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_syntax_node_find_child.c                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/29 10:34:24 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/01/29 10:41:31 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "syntax_analyze.h"
+
+t_syntax_node	*ms_syntax_node_find_child(
+					t_syntax_node *node, t_syntax_type type)
+{
+	t_syntax_node	*result;
+	int				pos;
+
+	pos = 0;
+	if (node->type == type)
+		return (node);
+	if (node->children == NULL)
+		return (NULL);
+	while (node->children[pos] != NULL)
+	{
+		result = ms_syntax_node_find_child(node->children[pos], type);
+		if (result != NULL)
+			return (result);
+		pos++;
+	}
+	return (NULL);
+}

--- a/src/syntax_analyze/ms_syntax_node_get_child.c
+++ b/src/syntax_analyze/ms_syntax_node_get_child.c
@@ -1,0 +1,30 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_syntax_node_get_child.c                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/23 05:09:08 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/01/29 10:39:04 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "syntax_analyze.h"
+
+t_syntax_node	*ms_syntax_node_get_child(
+					t_syntax_node *node, t_syntax_type type)
+{
+	int	pos;
+
+	pos = 0;
+	if (node -> children == NULL)
+		return (NULL);
+	while (node->children[pos] != NULL)
+	{
+		if (node->children[pos]->type == type)
+			return (node->children[pos]);
+		pos++;
+	}
+	return (NULL);
+}

--- a/src/syntax_analyze/ms_syntax_node_print.c
+++ b/src/syntax_analyze/ms_syntax_node_print.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/29 08:52:26 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/01/29 13:16:07 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/01/29 13:34:56 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -168,7 +168,7 @@ static void	ms_print_indent(int depth)
 	printf("%*s", depth * 2, "");
 }
 
-void	ms_print_token(const char *token)
+static void	ms_print_token(const char *token)
 {
 	while (*token != '\0')
 	{
@@ -194,7 +194,7 @@ void	ms_print_token(const char *token)
 	}
 }
 
-char	*ms_syntax_node_type_to_string(t_syntax_type type)
+static char	*ms_syntax_node_type_to_string(t_syntax_type type)
 {
 	size_t	i;
 
@@ -208,7 +208,7 @@ char	*ms_syntax_node_type_to_string(t_syntax_type type)
 	return ("UNKNOWN_TYPE");
 }
 
-char	*ms_syntax_node_type_to_color(t_syntax_type type)
+static char	*ms_syntax_node_type_to_color(t_syntax_type type)
 {
 	size_t	i;
 

--- a/src/syntax_analyze/ms_syntax_node_print.c
+++ b/src/syntax_analyze/ms_syntax_node_print.c
@@ -6,13 +6,12 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/29 08:52:26 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/01/29 10:04:14 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/01/29 13:16:07 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "syntax_analyze.h"
 #include <stdio.h>
-
 
 static void	**g_list[] = {
 	(void *[]){

--- a/src/syntax_analyze/ms_syntax_node_print.c
+++ b/src/syntax_analyze/ms_syntax_node_print.c
@@ -1,0 +1,224 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_syntax_node_print.c                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/29 08:52:26 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/01/29 10:04:14 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "syntax_analyze.h"
+#include <stdio.h>
+
+
+static void	**g_list[] = {
+	(void *[]){
+	(t_syntax_type []){SY_DECLINED},
+	"SY_DECLINED",
+	"\x1b[32;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_IDENTIFY},
+	"SY_IDENTIFY",
+	"\x1b[33;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_WORD},
+	"SY_WORD",
+	"\x1b[34;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_BLANK},
+	"SY_BLANK",
+	"\x1b[35;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_NEWLINE},
+	"SY_NEWLINE",
+	"\x1b[36;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_VARIABLE},
+	"SY_VARIABLE",
+	"\x1b[37;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_LIST_TOKEN},
+	"SY_LIST_TOKEN",
+	"\x1b[91;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_PIPE},
+	"SY_PIPE",
+	"\x1b[92;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_EQUALS},
+	"SY_EQUALS",
+	"\x1b[93;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_SINGLE_QUOTE},
+	"SY_SINGLE_QUOTE",
+	"\x1b[94;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_DOUBLE_QUOTE},
+	"SY_DOUBLE_QUOTE",
+	"\x1b[95;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_REDIRECTION},
+	"SY_REDIRECTION",
+	"\x1b[96;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_LEFT_PARENTHESIS},
+	"SY_LEFT_PARENTHESIS",
+	"\x1b[97;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_RIGHT_PARENTHESIS},
+	"SY_RIGHT_PARENTHESIS",
+	"\x1b[31;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_ALL},
+	"SY_ALL",
+	"\x1b[32;4m"},
+	(void *[]){
+	(t_syntax_type []){SY_DOUBLE_QUOTED_WORD},
+	"SY_DOUBLE_QUOTED_WORD",
+	"\x1b[33m"},
+	(void *[]){
+	(t_syntax_type []){SY_SINGLE_QUOTED_WORD},
+	"SY_SINGLE_QUOTED_WORD",
+	"\x1b[34m"},
+	(void *[]){
+	(t_syntax_type []){SY_WORD_LIST},
+	"SY_WORD_LIST",
+	"\x1b[35m"},
+	(void *[]){
+	(t_syntax_type []){SY_ASSIGNMENT_WORD},
+	"SY_ASSIGNMENT_WORD",
+	"\x1b[36m"},
+	(void *[]){
+	(t_syntax_type []){SY_REDIRECTION_WORD},
+	"SY_REDIRECTION_WORD",
+	"\x1b[37m"},
+	(void *[]){
+	(t_syntax_type []){SY_SIMPLE_COMMAND},
+	"SY_SIMPLE_COMMAND",
+	"\x1b[91m"},
+	(void *[]){
+	(t_syntax_type []){SY_ASSIGNMENT_COMMAND},
+	"SY_ASSIGNMENT_COMMAND",
+	"\x1b[92m"},
+	(void *[]){
+	(t_syntax_type []){SY_COMMAND},
+	"SY_COMMAND",
+	"\x1b[93m"},
+	(void *[]){
+	(t_syntax_type []){SY_PIPELINE},
+	"SY_PIPELINE",
+	"\x1b[94m"},
+	(void *[]){
+	(t_syntax_type []){SY_LIST},
+	"SY_LIST",
+	"\x1b[95m"},
+	(void *[]){
+	(t_syntax_type []){SY_COMPOUND_LIST},
+	"SY_COMPOUND_LIST",
+	"\x1b[96m"},
+	(void *[]){
+	(t_syntax_type []){SY_USER_INPUT},
+	"SY_USER_INPUT",
+	"\x1b[97m"},
+	(void *[]){
+	(t_syntax_type []){SY_INSTRUCTION},
+	"SY_INSTRUCTION",
+	"\x1b[31m"},
+	NULL
+};
+
+static void	ms_print_indent(int depth);
+static char	*ms_syntax_node_type_to_string(t_syntax_type type);
+static char	*ms_syntax_node_type_to_color(t_syntax_type type);
+static void	ms_print_token(const char *token);
+
+void	ms_syntax_node_print(t_syntax_node *node)
+{
+	static int	depth = 0;
+	size_t		i;
+
+	if (node == NULL)
+		return ;
+	ms_print_indent(depth);
+	printf("%s%s\x1b[0m", ms_syntax_node_type_to_color(node->type),
+		ms_syntax_node_type_to_string(node->type));
+	if (node->token != NULL)
+	{
+		printf(" -> '");
+		ms_print_token(node->token->token);
+		printf("`");
+	}
+	printf("\n");
+	if (node->children == NULL)
+		return ;
+	i = 0;
+	while (node->children[i] != NULL)
+	{
+		depth++;
+		ms_syntax_node_print(node->children[i]);
+		depth--;
+		i++;
+	}
+}
+
+static void	ms_print_indent(int depth)
+{
+	printf("%*s", depth * 2, "");
+}
+
+void	ms_print_token(const char *token)
+{
+	while (*token != '\0')
+	{
+		if (*token == '\n')
+			printf("\\n");
+		else if (*token == '\t')
+			printf("\\t");
+		else if (*token == '\r')
+			printf("\\r");
+		else if (*token == '\v')
+			printf("\\v");
+		else if (*token == '\f')
+			printf("\\f");
+		else if (*token == '\b')
+			printf("\\b");
+		else if (*token == '\a')
+			printf("\\a");
+		else if (*token == '\0')
+			printf("\\0");
+		else
+			printf("%c", *token);
+		token++;
+	}
+}
+
+char	*ms_syntax_node_type_to_string(t_syntax_type type)
+{
+	size_t	i;
+
+	i = 0;
+	while (g_list[i] != NULL)
+	{
+		if (((t_syntax_type *)g_list[i][0])[0] == type)
+			return ((char *)g_list[i][1]);
+		i++;
+	}
+	return ("UNKNOWN_TYPE");
+}
+
+char	*ms_syntax_node_type_to_color(t_syntax_type type)
+{
+	size_t	i;
+
+	i = 0;
+	while (g_list[i] != NULL)
+	{
+		if (((t_syntax_type *)g_list[i][0])[0] == type)
+			return ((char *)g_list[i][2]);
+		i++;
+	}
+	return ("\x1b[0m");
+}

--- a/tests/googletest/semantic_analyze/test_ms_compare_heredoc_input.cpp
+++ b/tests/googletest/semantic_analyze/test_ms_compare_heredoc_input.cpp
@@ -1,0 +1,22 @@
+
+#include <gtest/gtest.h>
+
+extern "C" {
+	#include "semantic_analyze.h"
+	#include "semantic_analyze_internal.h"
+	#include "syntax_analyze.h"
+	#include "lexer.h"
+	#include "libms.h"
+}
+
+TEST(ms_compare_heredoc_input, basic)
+{
+	EXPECT_TRUE(ms_compare_heredoc_input("abc\n", "abc\n"));
+	EXPECT_TRUE(ms_compare_heredoc_input("abc", "abc\n"));
+	EXPECT_TRUE(ms_compare_heredoc_input("abc\n", "abc"));
+	EXPECT_TRUE(ms_compare_heredoc_input("abc", "abc"));
+	EXPECT_FALSE(ms_compare_heredoc_input("abca", "abcb"));
+	EXPECT_FALSE(ms_compare_heredoc_input("abc", " abc"));
+	EXPECT_FALSE(ms_compare_heredoc_input("abc", "abc "));
+	EXPECT_FALSE(ms_compare_heredoc_input("abc", " abc "));
+}

--- a/tests/googletest/semantic_analyze/test_ms_lsa_set_heredoc.cpp
+++ b/tests/googletest/semantic_analyze/test_ms_lsa_set_heredoc.cpp
@@ -24,7 +24,6 @@ TEST(ms_lsa_set_heredoc, basic)
 	EXPECT_NE(lsa_redirection->delimiter, nullptr);
 	EXPECT_NE(lsa_redirection->heredoc_input, nullptr);
 
-	ms_syntax_node_print(lsa_redirection->heredoc_input[0]);
 	ms_destroy_ntp2((void **)tokens, ms_lexical_analyze_destroy_token_wrapper);
 	ms_syntax_node_destroy(syntax_analyzed);
 	ms_lsa_destroy(lsa);

--- a/tests/googletest/semantic_analyze/test_ms_lsa_set_heredoc.cpp
+++ b/tests/googletest/semantic_analyze/test_ms_lsa_set_heredoc.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+	#include "semantic_analyze.h"
+	#include "semantic_analyze_internal.h"
+	#include "syntax_analyze.h"
+	#include "lexer.h"
+	#include "libms.h"
+}
+
+TEST(ms_lsa_set_heredoc, basic)
+{
+	t_lsa				*lsa;
+	t_syntax_node		*syntax_analyzed;
+	t_token				**tokens;
+	t_lsa_redirection	*lsa_redirection;
+
+	tokens = ms_lexical_analyze("echo test << word\nabc\nword\n");
+	syntax_analyzed = ms_syntax_analyze(tokens);
+	lsa = semantic_analyze(syntax_analyzed);
+
+	lsa_redirection = lsa->lists[0]->pipeline->commands[0]->redirects[0];
+	EXPECT_EQ(lsa_redirection->type, LSA_RD_HEREDOC);
+	EXPECT_NE(lsa_redirection->delimiter, nullptr);
+	EXPECT_NE(lsa_redirection->heredoc_input, nullptr);
+
+	ms_syntax_node_print(lsa_redirection->heredoc_input[0]);
+	ms_destroy_ntp2((void **)tokens, ms_lexical_analyze_destroy_token_wrapper);
+	ms_syntax_node_destroy(syntax_analyzed);
+	ms_lsa_destroy(lsa);
+}

--- a/tests/googletest/syntax_analyze/test_ms_syntax_node_find_child.cpp
+++ b/tests/googletest/syntax_analyze/test_ms_syntax_node_find_child.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+	#include "syntax_analyze.h"
+	#include "lexer.h"
+	#include "libms.h"
+}
+
+TEST(ms_syntax_node_find_child, basic) {
+	t_syntax_node	*command_node;
+	t_syntax_node	*simple_command_node;
+	t_token			**tokens;
+	const char		*str;
+
+	str = "echo hello > file\n echo\nEOF\n";
+	tokens = ms_lexical_analyze(str);
+	command_node = ms_syntax_analyze(tokens);
+
+	simple_command_node = ms_syntax_node_find_child(command_node, SY_SIMPLE_COMMAND);
+	EXPECT_EQ(simple_command_node->type, SY_SIMPLE_COMMAND);
+
+	ms_syntax_node_destroy(command_node);
+	ms_destroy_ntp2((void **)tokens, ms_lexical_analyze_destroy_token_wrapper);
+}

--- a/tests/googletest/syntax_analyze/test_ms_syntax_node_get_child.cpp
+++ b/tests/googletest/syntax_analyze/test_ms_syntax_node_get_child.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+	#include "semantic_analyze.h"
+	#include "syntax_analyze.h"
+	#include "lexer.h"
+	#include "libms.h"
+}
+
+TEST(ms_lsa_get_child_node, basic) {
+	t_syntax_node	*command_node;
+	t_syntax_node	*user_input_node;
+	t_syntax_node	*simple_command_node;
+	t_token			**tokens;
+	const char		*str;
+
+	str = "echo hello > file\n echo\nEOF\n";
+	tokens = ms_lexical_analyze(str);
+	command_node = ms_syntax_analyze(tokens);
+
+	user_input_node = ms_syntax_node_get_child(command_node, SY_USER_INPUT);
+	EXPECT_EQ(user_input_node->type, SY_USER_INPUT);
+
+	simple_command_node = ms_syntax_node_find_child(command_node, SY_SIMPLE_COMMAND);
+	user_input_node = ms_syntax_node_get_child(simple_command_node, SY_WORD_LIST);
+	EXPECT_EQ(user_input_node->type, SY_WORD_LIST);
+
+	ms_syntax_node_destroy(command_node);
+	ms_destroy_ntp2((void **)tokens, ms_lexical_analyze_destroy_token_wrapper);
+}


### PR DESCRIPTION
ヒアドク用のLSA実装書きました。

つつにゃに影響がありそうな範囲の変更ファイル
 * src/semantic_analyze/lsa_destroy/ms_lsa_redirection_destroy.c
 * src/semantic_analyze/ms_lsa_redirection.c
 
以下の関数も追加しました。
 * syntax_nodeを標準出力に出力する関数
 * 特定のノードを検索する関数
 * 一番上のチャイルドの一つを取得する関数

t_lsa_redirectionのdelimiterとheredoc_inputに設定しました。
デリミタのノードと改行のノードは削除しています。

レビューお願いします。
