### PR TITLE
fix: heredoc input process

### DIFF
--- a/src/input/ms_set_delimita_list.c
+++ b/src/input/ms_set_delimita_list.c
@@ -87,13 +87,21 @@ void	ms_skip_until_heredoc(char **input)
 
 void	ms_skip_surround_quote(char **input)
 {
-	if (!ft_includes(**input, "'\""))
+	char	quote_txt[2];
+	char	*ptr;
+
+	ptr = *input;
+	if (!ft_includes(*ptr, "'\""))
 		return ;
-	(*input)++;
-	while (**input != '\0' && ! ft_includes(**input, "'\""))
-		(*input)++;
-	if (**input != '\0' && ft_includes(**input, "'\""))
-		(*input)++;
+	quote_txt[1] = '\0';
+	quote_txt[0] = *ptr;
+	ptr++;
+	while (*ptr != '\0' && ! ft_includes(*ptr, quote_txt))
+		ptr++;
+	if (*ptr == '\0')
+		return ;
+	ptr++;
+	*input = ptr;
 }
 
 void	ms_skip_set(char **input, const char *set)
@@ -105,8 +113,18 @@ void	ms_skip_set(char **input, const char *set)
 char	*ms_dup_delimita(char *input)
 {
 	char	*dup;
+	char	*end;
 
-	dup = ms_dup_until_sep(input, " \t\n<&|()");
+	end = input;
+	while (*end != '\0')
+ 	{
+		if (ft_includes(*end, "\"'"))
+			ms_skip_surround_quote(&end);
+		if (ft_includes(*end, " \t\n<&|()"))
+			break ;
+		end++;
+	}
+	dup = ft_strndup(input, end - input);
 	if (dup == NULL)
 		return (NULL);
 	ms_exclude_quote(dup);

--- a/src/input/ms_set_delimita_list.c
+++ b/src/input/ms_set_delimita_list.c
@@ -137,13 +137,22 @@ void	ms_exclude_quote(char *input)
 {
 	size_t	set_pos;
 	size_t	pivot;
+	char	quote_txt;
 
 	set_pos = 0;
 	pivot = 0;
+	quote_txt = '\0';
 	while (input[pivot] != '\0')
 	{
-		if (ft_includes(input[pivot], "'\""))
+		if (quote_txt != '\0' && input[pivot] == quote_txt)
 		{
+			quote_txt = '\0';
+			pivot++;
+			continue ;
+		}
+		else if (quote_txt == '\0' && ft_includes(input[pivot], "'\""))
+		{
+			quote_txt = input[pivot];
 			pivot++;
 			continue ;
 		}

--- a/src/input/ms_set_delimita_list.c
+++ b/src/input/ms_set_delimita_list.c
@@ -117,10 +117,12 @@ char	*ms_dup_delimita(char *input)
 
 	end = input;
 	while (*end != '\0')
- 	{
+	{
 		if (ft_includes(*end, "\"'"))
 			ms_skip_surround_quote(&end);
 		if (ft_includes(*end, " \t\n<&|()"))
+			break ;
+		if (*end == '\0')
 			break ;
 		end++;
 	}


### PR DESCRIPTION
ヒアドクに空白が含まれているときのバグを修正しました。

 * クォートの対応関係を無視した処理を修正しました。
 * クォートを飛ばしながら、区切り文字以外が含まれるまでを複製するようにしました。
レビューをお願いします。