### PR TITLE
add: memento

### DIFF
--- a/src/execution/memento/memento.h
+++ b/src/execution/memento/memento.h
@@ -1,0 +1,22 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   memento.h                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 20:15:48 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/03/19 12:12:45 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef MEMENTO_H
+# define MEMENTO_H
+
+# include "memento_type.h"
+
+t_environ_memento	*ms_save_environ_memento(void);
+int					ms_restore_environ_memento(t_environ_memento *memento);
+void				ms_memento_destroy(t_environ_memento *memento);
+
+#endif

--- a/src/execution/memento/memento_type.h
+++ b/src/execution/memento/memento_type.h
@@ -1,0 +1,22 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   memento_type.h                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 20:16:04 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/03/19 20:16:44 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef MEMENTO_TYPE_H
+# define MEMENTO_TYPE_H
+
+typedef struct s_environ_memento {
+	int	stdin_fd;
+	int	stdout_fd;
+	int	stderr_fd;
+}	t_environ_memento;
+
+#endif

--- a/src/execution/memento/ms_memento_destroy.c
+++ b/src/execution/memento/ms_memento_destroy.c
@@ -1,0 +1,19 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_memento_destroy.c                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 12:12:52 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/03/19 12:13:44 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "memento_type.h"
+#include <stdlib.h>
+
+void	ms_memento_destroy(t_environ_memento *memento)
+{
+	free(memento);
+}

--- a/src/execution/memento/ms_restore_environ_memento.c
+++ b/src/execution/memento/ms_restore_environ_memento.c
@@ -1,0 +1,25 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_restore_environ_memento.c                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 20:18:49 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/03/19 20:19:22 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "memento.h"
+#include <unistd.h>
+
+int	ms_restore_environ_memento(t_environ_memento *memento)
+{
+	if (dup2(memento->stdin_fd, STDIN_FILENO) == -1)
+		return (-1);
+	if (dup2(memento->stdout_fd, STDOUT_FILENO) == -1)
+		return (-1);
+	if (dup2(memento->stderr_fd, STDERR_FILENO) == -1)
+		return (-1);
+	return (0);
+}

--- a/src/execution/memento/ms_save_environ_memento.c
+++ b/src/execution/memento/ms_save_environ_memento.c
@@ -1,0 +1,36 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_save_environ_memento.c                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 20:15:35 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/03/19 20:28:24 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "memento.h"
+#include <stdlib.h>
+#include <unistd.h>
+
+t_environ_memento	*ms_save_environ_memento(void)
+{
+	t_environ_memento	*memento;
+	t_environ_memento	tmp_memento;
+
+	tmp_memento.stdin_fd = dup(STDIN_FILENO);
+	if (tmp_memento.stdin_fd == -1)
+		return (NULL);
+	tmp_memento.stdout_fd = dup(STDOUT_FILENO);
+	if (tmp_memento.stdout_fd == -1)
+		return (NULL);
+	tmp_memento.stderr_fd = dup(STDERR_FILENO);
+	if (tmp_memento.stderr_fd == -1)
+		return (NULL);
+	memento = (t_environ_memento *)malloc(sizeof(t_environ_memento));
+	if (memento == NULL)
+		return (NULL);
+	*memento = tmp_memento;
+	return (memento);
+}

--- a/src/execution/ms_simple_command_execution..c
+++ b/src/execution/ms_simple_command_execution..c
@@ -3,15 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   ms_simple_command_execution..c                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rnakatan <rnakatan@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/26 21:31:38 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/03/15 18:02:12 by rnakatan         ###   ########.fr       */
+/*   Updated: 2025/03/19 12:13:29 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "execution.h"
 #include "libms.h"
+#include "memento/memento.h"
 #include <stdlib.h>
 
 static int	ms_simple_command_execution_with_args(t_lsa_command *lsa_command);
@@ -19,9 +20,13 @@ static int	ms_simple_command_execution_no_args(t_lsa_command *lsa_command);
 
 int	ms_simple_command_execution(t_lsa_command *lsa_command)
 {
-	int	ret;
+	int					ret;
+	t_environ_memento	*env_memento;
 
 	ret = 0;
+	env_memento = ms_save_environ_memento();
+	if (env_memento == NULL)
+		return (1);
 	if (lsa_command->args)
 	{
 		ret = ms_simple_command_execution_with_args(lsa_command);
@@ -30,6 +35,9 @@ int	ms_simple_command_execution(t_lsa_command *lsa_command)
 	{
 		ret = ms_simple_command_execution_no_args(lsa_command);
 	}
+	if (ms_restore_environ_memento(env_memento) == -1)
+		ret = 1;
+	ms_memento_destroy(env_memento);
 	return (ret);
 }
 


### PR DESCRIPTION

出力リダイレクト単体で実行したときの問題を修正しました。

 コマンド単体を実行するときにmementoにfdを保存して、実行終了したらfdを復活させるように処理させています。