### PR TITLE
fix: option judgement condition

### DIFF
--- a/src/builtins/cd/cd_internal_type.h
+++ b/src/builtins/cd/cd_internal_type.h
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/01 05:44:12 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/02/01 07:48:02 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/21 11:04:52 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,7 @@ typedef struct s_builtin_cd
 {
 	bool	symlink_follow;
 	bool	is_set_cwd_error;
+	bool	is_to_oldpwd;
 	char	*chdir_pathname;
 }	t_builtin_cd;
 

--- a/src/builtins/cd/ms_builtin_cd.c
+++ b/src/builtins/cd/ms_builtin_cd.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/01 06:29:14 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/05 13:02:05 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/21 11:12:49 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <stdio.h>
 
 static int	ms_builtin_cd2(t_builtin_cd *parsed);
 static int	ms_setnewpwd(t_builtin_cd *parsed, const char *chdir_pathname);
@@ -51,6 +52,8 @@ static int	ms_builtin_cd2(t_builtin_cd *parsed)
 		return (ms_perror_cmd("cd", strerror(errno)), 1);
 	if (chdir(resolved_path) == -1)
 		return (ms_perror_cd(resolved_path), free(resolved_path), 1);
+	if (parsed->is_to_oldpwd)
+		printf("%s\n", resolved_path);
 	result = ms_setnewpwd(parsed, resolved_path);
 	free(resolved_path);
 	return (result);

--- a/src/builtins/cd/ms_parse_builtin_cd_args.c
+++ b/src/builtins/cd/ms_parse_builtin_cd_args.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/01 05:45:21 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/02/11 07:39:14 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/21 11:12:09 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,7 @@ int	ms_parse_builtin_cd_args(
 	parsed->chdir_pathname = NULL;
 	parsed->is_set_cwd_error = false;
 	parsed->symlink_follow = false;
+	parsed->is_to_oldpwd = false;
 	argc = (int)ms_ntpsize((void **)argv);
 	ms_getopt_init(&opting, argc, (char **)argv, "LPe");
 	status = __ms_parse_builtin_cd_args(parsed, &opting);
@@ -61,6 +62,8 @@ static int	__ms_parse_builtin_cd_args(t_builtin_cd *parsed, t_opting *opting)
 	args = opting->argv + opting->optind;
 	if (args[0] != NULL && args[1] != NULL)
 		return (ms_perror_cmd("cd", "too many arguments"), 1);
+	if (args[0] != NULL && ft_strcmp(args[0], "-") == 0)
+		parsed->is_to_oldpwd = true;
 	parsed->chdir_pathname = ms_get_cd_path(args[0]);
 	if (parsed->chdir_pathname == NULL)
 		return (ms_perror_cmd("cd", strerror(errno)), 1);

--- a/src/builtins/modules/getopt/ms_go_is_option.c
+++ b/src/builtins/modules/getopt/ms_go_is_option.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 11:10:27 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/01/31 15:54:20 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/19 12:29:32 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@ bool	ms_go_is_option(const char *arg)
 {
 	if (ft_strcmp(arg, "--") == 0)
 		return (false);
-	else if (arg[0] == '-')
+	else if (arg[0] == '-' && arg[1] != '\0')
 		return (true);
 	else
 		return (false);


### PR DESCRIPTION

`cd -`が実行されなかったのは、`-`もオプションとして判定されているためでした。
`-`は引数として扱うことで問題を回避しました。
