### PR TITLE
146 bug echo コマンドで不正なオプションがあればそこから出力すること

### DIFF
--- a/src/builtins/echo/ms_parse_builtin_echo_arg.c
+++ b/src/builtins/echo/ms_parse_builtin_echo_arg.c
@@ -6,13 +6,14 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 16:46:25 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/01/31 16:48:43 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/19 12:56:38 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin_echo_type.h"
 #include "libms.h"
 #include "ms_getopt.h"
+#include <stdio.h>
 
 int	ms_parse_builtin_echo_arg(
 		t_builtin_echo *parsed,
@@ -21,6 +22,7 @@ int	ms_parse_builtin_echo_arg(
 		char *const envp[])
 {
 	int			argc;
+	int			pre_optind;
 	t_opting	opting;
 
 	(void)path;
@@ -29,10 +31,15 @@ int	ms_parse_builtin_echo_arg(
 	argc = (int)ms_ntpsize((void **)argv);
 	ms_getopt_init(&opting, argc, (char **)argv, "n");
 	opting.is_skip_double_hyphen = false;
+	pre_optind = opting.optind;
 	while (ms_getopt_parse(&opting))
 	{
 		if (opting.is_valid_optstatement == false)
+		{
+			if (pre_optind != opting.optind)
+				opting.optind = pre_optind;
 			break ;
+		}
 		parsed->is_n = true;
 	}
 	parsed->arg_index = opting.optind;

--- a/src/builtins/echo/ms_parse_builtin_echo_arg.c
+++ b/src/builtins/echo/ms_parse_builtin_echo_arg.c
@@ -6,14 +6,13 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 16:46:25 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/19 13:19:02 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/19 13:21:13 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin_echo_type.h"
 #include "libms.h"
 #include "ms_getopt.h"
-#include <stdio.h>
 
 int	ms_parse_builtin_echo_arg(
 		t_builtin_echo *parsed,

--- a/src/builtins/echo/ms_parse_builtin_echo_arg.c
+++ b/src/builtins/echo/ms_parse_builtin_echo_arg.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 16:46:25 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/19 13:14:20 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/19 13:19:02 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,6 +39,7 @@ int	ms_parse_builtin_echo_arg(
 			opting.optind = pre_optind;
 			break ;
 		}
+		pre_optind = opting.optind;
 		parsed->is_n = true;
 	}
 	parsed->arg_index = opting.optind;

--- a/src/builtins/echo/ms_parse_builtin_echo_arg.c
+++ b/src/builtins/echo/ms_parse_builtin_echo_arg.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/31 16:46:25 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/19 12:56:38 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/19 13:14:20 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,8 +36,7 @@ int	ms_parse_builtin_echo_arg(
 	{
 		if (opting.is_valid_optstatement == false)
 		{
-			if (pre_optind != opting.optind)
-				opting.optind = pre_optind;
+			opting.optind = pre_optind;
 			break ;
 		}
 		parsed->is_n = true;

--- a/tests/googletest/builtins/echo/test_ms_builtin_echo.cpp
+++ b/tests/googletest/builtins/echo/test_ms_builtin_echo.cpp
@@ -150,7 +150,7 @@ TEST(builtin_echo, valid2invalid_option)
 	const char *args[] = {"echo", "-n", "-na", NULL};
 
 	output = ms_get_output(args);
-	EXPECT_EQ(output, "-a\n");
+	EXPECT_EQ(output, "-na");
 }
 
 static std::string	ms_get_output(const char *args[])

--- a/tests/googletest/builtins/echo/test_ms_builtin_echo.cpp
+++ b/tests/googletest/builtins/echo/test_ms_builtin_echo.cpp
@@ -143,6 +143,16 @@ TEST(builtin_echo, invalid_option)
 	EXPECT_EQ(output, "-a\n");
 }
 
+/** 正しいオプション => 不正なオプションでも動作すること */
+TEST(builtin_echo, valid2invalid_option)
+{
+	std::string output;
+	const char *args[] = {"echo", "-n", "-na", NULL};
+
+	output = ms_get_output(args);
+	EXPECT_EQ(output, "-a\n");
+}
+
 static std::string	ms_get_output(const char *args[])
 {
 	CaptureFd cap;

--- a/tests/googletest/builtins/echo/test_ms_builtin_echo.cpp
+++ b/tests/googletest/builtins/echo/test_ms_builtin_echo.cpp
@@ -133,6 +133,16 @@ TEST(builtin_echo, no_argument)
     EXPECT_EQ(output, "\n");
 }
 
+/** オプションが問題でも動作すること */
+TEST(builtin_echo, invalid_option)
+{
+	std::string output;
+	const char *args[] = {"echo", "-a", NULL};
+
+	output = ms_get_output(args);
+	EXPECT_EQ(output, "-a\n");
+}
+
 static std::string	ms_get_output(const char *args[])
 {
 	CaptureFd cap;


### PR DESCRIPTION
-a のように不正なオプション引数だけだと次の引数を見てしまっていた。

テストの追加とこの問題を修正した。
