### PR TITLE
153 bug 起動時に履歴が読み込まれていない

### DIFF
--- a/src/finalize/ms_cleanup_and_exit.c
+++ b/src/finalize/ms_cleanup_and_exit.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/15 13:46:44 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/17 13:05:53 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/19 14:21:12 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,8 +25,8 @@ void	ms_cleanup_and_exit(int status)
 	{
 		printf("exit\n");
 		ms_add_mnsh_history("exit");
+		ms_export_history();
 	}
-	ms_export_history();
 	ms_clear_history();
 	ms_clear_cdwd();
 	ms_clear_environ(NULL);

--- a/src/history/internal/history_internal.h
+++ b/src/history/internal/history_internal.h
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/19 07:22:08 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/01/19 12:10:15 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/19 13:45:12 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,8 @@ int			ms_write_history_history(t_history *history, const char *filename);
 void		ms_init_history(t_history *history);
 int			ms_append_history_history(
 				t_history *history, int nelements, const char *filename);
+void		ms_update_maxentries_from_env(t_history *history);
+
 /**
  * variable
  */

--- a/src/history/internal/ms_update_maxentries_from_env.c
+++ b/src/history/internal/ms_update_maxentries_from_env.c
@@ -1,0 +1,22 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_update_maxentries_from_env.c                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 13:43:28 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/03/19 14:01:52 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "history_internal_type.h"
+#include "libms.h"
+
+void	ms_update_maxentries_from_env(t_history *history)
+{
+	if (ms_getenv("HISTSIZE") == NULL)
+		history->history_max_entries = -1;
+	else
+		history->history_max_entries = ft_atoi(ms_getenv("HISTSIZE"));
+}

--- a/src/history/ms_read_history.c
+++ b/src/history/ms_read_history.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/18 11:10:28 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/01/19 10:09:26 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/19 13:45:27 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,7 @@ int	ms_read_history(const char *filename)
 	t_list		*history_list;
 
 	history = ms_history();
+	ms_update_maxentries_from_env(&history);
 	ret_errno = ms_read_history_history(&history, filename);
 	history_list = history.history;
 	while (history_list != NULL)

--- a/src/setup/ms_setup_history.c
+++ b/src/setup/ms_setup_history.c
@@ -6,18 +6,21 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/18 12:14:00 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/01/18 18:04:37 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/19 14:16:44 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libms.h"
 #include "history.h"
+#include "setup.h"
 #include <stdio.h>
 
 int	ms_setup_history(void)
 {
 	char	*filename;
 
+	if (ms_is_interactive() == false)
+		return (0);
 	filename = ms_getenv("HISTFILE");
 	if (filename == NULL)
 		filename = "~/.mnsh_history";


### PR DESCRIPTION
表題の通り修正しました。
ついでに、非インタラクティブなシェル時、サブシェル時に履歴がファイルに書き出されてしまう動作を修正しました。