### PR TITLE
136 bug minishellからminishellが起動できない

### DIFF
--- a/src/execution/expantion/ms_pathname_expansion.c
+++ b/src/execution/expantion/ms_pathname_expansion.c
@@ -50,9 +50,11 @@ static int	ms_expand_path(t_syntax_node *word_node, t_list **child_node_lst)
 {
 	char			*expanded_string;
 	t_list			*expanded_node_lst;
+	const char		*token_string = word_node->token->token;
 
 	expanded_node_lst = NULL;
-	if (word_node->type == SY_WORD)
+	if (word_node->type == SY_WORD
+		&& ft_strchr(token_string, '*'))
 	{
 		expanded_string = ms_expand_path2((char *)word_node->token->token);
 		if (expanded_string == NULL)

--- a/tests/pytest/general/test_command/test_absolute_path.sh
+++ b/tests/pytest/general/test_command/test_absolute_path.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# テスト用の設定の読み込み
+cd "$(dirname $0)"
+. "../../test_prepare.sh"
+
+# テスト
+LEAKCHECK="valgrind -q --error-exitcode=12 --leak-check=full"
+$LEAKCHECK $PROG << "EOF"
+/bin/ls
+EOF

--- a/tests/pytest/general/test_command/test_command.py
+++ b/tests/pytest/general/test_command/test_command.py
@@ -1,5 +1,6 @@
 import script_tester
 import pytest
+import subprocess
 
 def test_invalid_option():
     script_tester.test("general/test_command/test_command_not_found.sh",
@@ -12,3 +13,10 @@ def test_initial_status():
         expected_stdout = "0\n",
         expected_stderr = (
             ""))
+
+def test_absolute_path():
+    result = subprocess.run(['/bin/ls','general/test_command'], capture_output=True, text=True)
+    script_tester.test("general/test_command/test_absolute_path.sh",
+        expected_stdout = result.stdout,
+        expected_stderr = ""
+        )


### PR DESCRIPTION
## issueに表記のbugの発生理由
パス名展開において、'\*'が含まれる文字列にのみ適応したい処理をSY_WORDのトークン全てに適応させていたため。

## 修正内容
パス名展開を行う条件式「トークンタイプがSY_WORDであるか」に「トークンに\*が含まれる場合」を論理積で加えた。

## 書いたテストの内容
- `/bin/ls`を実行した時の挙動の比較テスト (test_absolute_path.sh)

## 本件を修正することで解決した他のissue
https://github.com/PalmNeko/minishell/issues/170
https://github.com/PalmNeko/minishell/issues/168

#168 に関しては、セグフォしなくなったが #169と同一の問題が起きている。

レビュー宜しくお願いします！