### PR TITLE
145-bug-histcmdがunsetされた後の挙動 

### DIFF
--- a/src/history/ms_update_history_variable.c
+++ b/src/history/ms_update_history_variable.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/19 11:20:46 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/01/22 05:53:15 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/26 03:07:41 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,6 +46,8 @@ static void	ms_update_histcmd(void)
 	if (ms_unstifle_history() == 0)
 		ms_reset_histcmd();
 	history = ms_history();
+	if (history.enable_history_cmd == false)
+		return ;
 	if (ms_unstifle_history() != 0 && history.history_cmd == 0)
 	{
 		history.history_cmd = 1;

--- a/tests/pytest/general/test_variable/test_HISTCMD_unset.sh
+++ b/tests/pytest/general/test_variable/test_HISTCMD_unset.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# テスト用の設定の読み込み
+cd "$(dirname $0)"
+. "../../test_prepare.sh"
+
+# テスト
+LEAKCHECK="valgrind -q --error-exitcode=12 --leak-check=full"
+$LEAKCHECK $PROG << "EOF"
+unset HISTCMD
+HISTCMD=3
+echo $HISTCMD
+echo $HISTCMD
+EOF

--- a/tests/pytest/general/test_variable/test_variable.py
+++ b/tests/pytest/general/test_variable/test_variable.py
@@ -44,3 +44,10 @@ def test_SHLVL_invalid_value():
         expected_stderr = (
 			""
 			))
+
+def test_HISTCMD_unset():
+    script_tester.test("general/test_variable/test_HISTCMD_unset.sh",
+        expected_stdout = (
+            "3\n"
+            "3\n"),
+        expected_stderr = "")


### PR DESCRIPTION
* HISTCMDがunsetされたら、histcmdの更新を停止するように修正しました。

テストは、general/test_variable以下に作成予定ですが、別のPRでもここにテストを作成しました。
競合すると嫌なので他のPR #181 がマージ後、このブランチにマージして、作成予定です。
