### PR TITLE
151-bug-envコマンドでシェル変数も表示されてしまう

### DIFF
--- a/src/builtins/env-command/ms_builtin_env.c
+++ b/src/builtins/env-command/ms_builtin_env.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/30 19:31:02 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/05 13:05:35 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/26 03:50:07 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,13 +19,12 @@
 
 static int	ms_parse_builtin_env(t_opting *opting);
 static void	ms_print_usage_env(void);
+static void	ms_print_environ(void);
 
 int	ms_builtin_env(const char *path, char *const argv[], char *const envp[])
 {
 	int			status;
 	int			argc;
-	char		**environs;
-	char		**head;
 	t_opting	opting;
 
 	(void)path;
@@ -35,14 +34,7 @@ int	ms_builtin_env(const char *path, char *const argv[], char *const envp[])
 	status = ms_parse_builtin_env(&opting);
 	if (status != 0)
 		return (status);
-	environs = ms_export_env();
-	head = environs;
-	while (head != NULL && *head != NULL)
-	{
-		printf("%s\n", *head);
-		head++;
-	}
-	ms_destroy_ntp(environs);
+	ms_print_environ();
 	return (0);
 }
 
@@ -65,4 +57,22 @@ static int	ms_parse_builtin_env(t_opting *opting)
 static void	ms_print_usage_env(void)
 {
 	ft_putendl_fd("env: usage: env", 2);
+}
+
+static void	ms_print_environ(void)
+{
+	char	**names;
+	char	*value;
+
+	names = ms_export_names();
+	if (names == NULL)
+		return ;
+	while (*names != NULL)
+	{
+		value = ms_getenv(*names);
+		if (value != NULL)
+			printf("%s=%s\n", *names, value);
+		names++;
+	}
+	ms_destroy_ntp(names);
 }

--- a/src/builtins/env-command/ms_builtin_env.c
+++ b/src/builtins/env-command/ms_builtin_env.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/30 19:31:02 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/26 03:50:07 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/26 04:55:11 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,11 +62,13 @@ static void	ms_print_usage_env(void)
 static void	ms_print_environ(void)
 {
 	char	**names;
+	char	**head;
 	char	*value;
 
 	names = ms_export_names();
 	if (names == NULL)
 		return ;
+	head = names;
 	while (*names != NULL)
 	{
 		value = ms_getenv(*names);
@@ -74,5 +76,5 @@ static void	ms_print_environ(void)
 			printf("%s=%s\n", *names, value);
 		names++;
 	}
-	ms_destroy_ntp(names);
+	ms_destroy_ntp(head);
 }

--- a/src/include/libms.h
+++ b/src/include/libms.h
@@ -91,6 +91,7 @@ void			ms_perror_cmd2(
 					const char *name, const char *type, const char *msg);
 
 // exports
+char			**ms_export_names(void);
 t_list			*ms_get_exports(void);
 void			ms_set_exports(t_list *exports);
 void			ms_clear_exports(void);

--- a/src/libms/ms_export_exports.c
+++ b/src/libms/ms_export_exports.c
@@ -1,0 +1,33 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_export_exports.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/26 03:32:02 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/03/26 03:50:59 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libms.h"
+#include "libft.h"
+#include <stdlib.h>
+
+char	**ms_export_names(void)
+{
+	char	**names;
+	t_list	*lst;
+	t_list	*dupped_lst;
+
+	lst = ms_get_exports();
+	if (lst == NULL)
+		return (ft_calloc(1, sizeof(char *)));
+	dupped_lst = ft_lstmap(lst, (void *(*)(void *))ft_strdup, free);
+	if (dupped_lst == NULL)
+		return (NULL);
+	names = ms_lst_to_ntp(&dupped_lst, ms_identify, ms_noop_del);
+	if (names == NULL)
+		return (ft_lstclear(&dupped_lst, free), NULL);
+	return (names);
+}

--- a/tests/googletest/builtins/env-command/test_ms_builtin_env.cpp
+++ b/tests/googletest/builtins/env-command/test_ms_builtin_env.cpp
@@ -10,6 +10,9 @@ extern "C" {
 };
 
 typedef std::tuple<std::string, std::string, int> TestResult;
+static auto getStdout = [](const TestResult &t) { return std::get<0>(t); };
+static auto getStderr = [](const TestResult &t) { return std::get<1>(t); };
+static auto getStatus = [](const TestResult &t) { return std::get<2>(t); };
 
 /**
  * return stdout stderr status
@@ -53,91 +56,82 @@ std::tuple<std::string, std::string, int> test_runner_of_builtin_env(char **args
 	return t;
 }
 
+std::string	generate_expect_env_output(const char **envp)
+{
+	std::string output;
+
+	while (*envp != NULL)
+	{
+		output += *envp;
+		output += "\n";
+		envp++;
+	}
+	return output;
+}
+
 /** envコマンドと一致することを確認する */
 TEST(ms_builtin_env, equal_env_command)
 {
-	IoTerminal 	term;
-	IoTerminal	envTerm;
-	std::string expectStderr;
-	std::string expectStdout;
-	int			expect_status;
-	int			status;
+	TestResult 	expect;
+	TestResult 	result;
 	const char 	*args[] = {"env", NULL};
-	char		**envp;
-	char		**envp_itr;
+	const char	*envp[] = {
+		"PATH=/usr/bin:/bin",
+		"HOME=/home/user",
+		"USER=user",
+		NULL
+	};
+	std::string expect_stdout;
 
-	envp = ms_export_env();
-	envTerm.boot();
-	envp_itr = envp;
-	while (*envp_itr != NULL)
-		printf("%s\n", *(envp_itr++));
-	fflush(stdout);
-	envTerm.exit();
+	expect_stdout = generate_expect_env_output(envp);
+	expect = std::make_tuple(expect_stdout, "", 0);
 
-	expect_status = 0;
-	expectStdout = envTerm.getStdout();
-	expectStderr = envTerm.getStderr();
-
-	term.boot();
-	status = ms_builtin_env(NULL, (char *const *)args, envp);
-	fflush(stdout);
-	term.exit();
-	ms_destroy_ntp(envp);
-	EXPECT_EQ(status, expect_status);
-    EXPECT_EQ(term.getStdout(), expectStdout);
-    EXPECT_EQ(term.getStderr(), expectStderr);
+	result = test_runner_of_builtin_env((char **)args, (char **)envp);
+	EXPECT_EQ(getStdout(expect), getStdout(result));
+	EXPECT_EQ(getStderr(expect), getStderr(result));
+	EXPECT_EQ(getStatus(expect), getStatus(result));
 }
 
 /** envコマンドに無効なオプションが渡されたときはエラー */
 TEST(ms_builtin_env, error_on_invalid_opt)
 {
-	IoTerminal 	term;
-	std::string expectStderr;
-	std::string expectStdout;
-	int			expect_status;
-	int			status;
+	TestResult 	expect;
+	TestResult 	result;
 	const char 	*args[] = {"env", "-a", NULL};
 	char		**envp;
 
+	expect = std::make_tuple(
+		"",
+		(
+			"minishell: env: -a: invalid option\n"
+			"env: usage: env\n"
+		),
+		2);
 	envp = ms_export_env();
 	ASSERT_NE(envp, nullptr);
-	expect_status = 2;
-	expectStdout =
-		"";
-	expectStderr =
-		"minishell: env: -a: invalid option\n"
-		"env: usage: env\n";
-
-	term.boot();
-	status = ms_builtin_env(NULL, (char *const *)args, envp);
-	fflush(stdout);
-	term.exit();
+	result = test_runner_of_builtin_env((char **)args, envp);
 	ms_destroy_ntp(envp);
-	EXPECT_EQ(status, expect_status);
-    EXPECT_EQ(term.getStdout(), expectStdout);
-    EXPECT_EQ(term.getStderr(), expectStderr);
+
+	EXPECT_EQ(getStdout(expect), getStdout(result));
+	EXPECT_EQ(getStderr(expect), getStderr(result));
+	EXPECT_EQ(getStatus(expect), getStatus(result));
 }
 
 /** 引数は無視する */
 TEST(ms_builtin_env, ignore_argument)
 {
-	IoTerminal 	term;
-	IoTerminal	envTerm;
-	std::string expectStderr;
-	std::string expectStdout;
-	int			expect_status;
-	int			status;
+	TestResult 	expect;
+	TestResult 	result;
 	const char 	*args[] = {"env", "--", "-a", NULL};
+	char		**envp;
 
-	expect_status = 1;
-	expectStdout = "";
-	expectStderr = "minishell: env: too many arguments\n";
+	expect = std::make_tuple("", "minishell: env: too many arguments\n", 1);
+	envp = ms_export_env();
+	ASSERT_NE(envp, nullptr);
+	result = test_runner_of_builtin_env((char **)args, envp);
+	ms_destroy_ntp(envp);
 
-	term.boot();
-	status = ms_builtin_env(NULL, (char *const *)args, NULL);
-	fflush(stdout);
-	term.exit();
-	EXPECT_EQ(status, expect_status);
-    EXPECT_EQ(term.getStdout(), expectStdout);
-    EXPECT_EQ(term.getStderr(), expectStderr);
+	EXPECT_EQ(getStdout(expect), getStdout(result));
+	EXPECT_EQ(getStderr(expect), getStderr(result));
+	EXPECT_EQ(getStatus(expect), getStatus(result));
 }

--- a/tests/googletest/builtins/env-command/test_ms_builtin_env.cpp
+++ b/tests/googletest/builtins/env-command/test_ms_builtin_env.cpp
@@ -9,6 +9,50 @@ extern "C" {
 	#include <sys/types.h>
 };
 
+typedef std::tuple<std::string, std::string, int> TestResult;
+
+/**
+ * return stdout stderr status
+ */
+std::tuple<std::string, std::string, int> test_runner_of_builtin_env(char **args, char **envp)
+{
+
+	int status;
+	std::string stdOut;
+	std::string stdErr;
+	std::tuple<std::string, std::string, int> t;
+
+	// 環境変数の設定
+	ms_clear_exports();
+	while (envp != NULL && *envp != NULL)
+	{
+		char	*name;
+		char	*nameend;
+		char	*value;
+
+		nameend = ft_strchr(*envp, '=');
+		if (nameend != NULL)
+		{
+			name = ft_strndup(*envp, nameend - *envp);
+			value = ft_strdup(nameend + 1);
+			ms_setenv(name, value, 1);
+			ms_add_export(name);
+			free(name);
+			free(value);
+		}
+		envp++;
+	}
+
+	// 実行
+	testing::internal::CaptureStdout();
+	testing::internal::CaptureStderr();
+	status = ms_builtin_env(NULL, args, NULL);
+	stdOut = testing::internal::GetCapturedStdout();
+	stdErr = testing::internal::GetCapturedStderr();
+	t = std::make_tuple(stdOut, stdErr, status);
+	return t;
+}
+
 /** envコマンドと一致することを確認する */
 TEST(ms_builtin_env, equal_env_command)
 {

--- a/tests/googletest/builtins/export/test_ms_builtin_export.cpp
+++ b/tests/googletest/builtins/export/test_ms_builtin_export.cpp
@@ -41,6 +41,7 @@ TEST(ms_builtin_export, basic)
 
 	// 設定
 	ms_clear_environ(NULL);
+	ms_clear_exports();
 	ms_setenv("Alice", "10", 1);
 	ms_setenv("Chocolate", "", 1);
 	ms_add_export("Bob");


### PR DESCRIPTION
シェル変数を除いた変数のみを出力するように修正しました。

~~#178 と関係しているPRで、初期状態でexportされていないとそもそも出力されないので、それがマージされ次第、これもテストしてPRをONにする予定。~~
全然関係してなかった・・・わけでもないが、googleTestの方でテストを書けば問題なかった。

exportでバグった分を修正。
envのテストをC++の形式に書き換えたあと、変数のチェックのロジックを変更した。