### PR TITLE
128 bug export で足された場合の挙動が実装されていない

### DIFF
--- a/src/builtins/export/ms_export_variables.c
+++ b/src/builtins/export/ms_export_variables.c
@@ -6,13 +6,12 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/02 11:04:28 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/26 12:23:39 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/27 08:10:31 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libms.h"
 #include "libft.h"
-#include "export_internal_def.h"
 #include <stdlib.h>
 #include <stddef.h>
 
@@ -90,8 +89,9 @@ static int	ms_export_append_variable(const char *arg)
 	if (ms_add_export(name) == -1)
 		return (free(name), 1);
 	if (ms_getenv(name) == NULL)
-		return (free(name), 0);
-	value = ft_strdup(ms_getenv(name));
+		value = ft_strdup("");
+	else
+		value = ft_strdup(ms_getenv(name));
 	if (value == NULL)
 		return (free(name), 1);
 	if (ms_replace_joined_str(&value, name_end + 2) == NULL)

--- a/src/include/libms.h
+++ b/src/include/libms.h
@@ -20,6 +20,7 @@
 
 /** string.h */
 char			*ms_strpbrk(const char *s, const char *accept);
+char			*ms_strstr(const char *haystack, const char *needle);
 
 /** unistd.h */
 char			*ms_get_current_dir_name(void);

--- a/src/libms/ms_strstr.c
+++ b/src/libms/ms_strstr.c
@@ -1,0 +1,24 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_strstr.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/26 10:23:35 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/03/26 10:24:30 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+char	*ms_strstr(const char *haystack, const char *needle)
+{
+	while (*haystack != '\0')
+	{
+		if (ft_strncmp(haystack, needle, ft_strlen(needle)) == 0)
+			return ((char *)haystack);
+		haystack++;
+	}
+	return (NULL);
+}

--- a/tests/googletest/builtins/export/test_ms_builtin_export.cpp
+++ b/tests/googletest/builtins/export/test_ms_builtin_export.cpp
@@ -62,7 +62,7 @@ TEST(ms_builtin_export, basic)
 TEST(ms_builtin_export, can_set_environ)
 {
 	const char 	*args[] = {"export", "A==123", "B=321=", "C=", "D", NULL};
-
+	const char 	*args2[] = {"export", "A+==123", "B+=", NULL};
 
 	// 設定
 	ms_clear_environ(NULL);
@@ -76,6 +76,13 @@ TEST(ms_builtin_export, can_set_environ)
 	EXPECT_STREQ(ms_getenv("B"), "321=");
 	EXPECT_STREQ(ms_getenv("C"), "");
 	EXPECT_EQ(ms_getenv("D"), nullptr);
+
+	// 実行
+	ms_builtin_export(NULL, (char *const *)args2, NULL);
+
+	// テスト
+	EXPECT_STREQ(ms_getenv("A"), "=123=123");
+	EXPECT_STREQ(ms_getenv("B"), "321=");
 }
 
 /** エラーのテスト */


### PR DESCRIPTION
exportに+=で処理を書くとすでにある変数の後ろにデータをくっつけるような処理にした。

exportのリークは、 https://github.com/PalmNeko/minishell/pull/185 がマージされ次第修正予定。
#187を無理やり書き換えたため、変になっているかもしれませんが確認お願いします。