### PR TITLE
133 bug exportで識別子にできない文字の場合のエラー表示

### DIFF
--- a/src/builtins/export/export_internal.h
+++ b/src/builtins/export/export_internal.h
@@ -18,5 +18,6 @@
 int		ms_export_print_command(void);
 int		ms_export_variables(const char **args);
 char	**ms_export_environs(void);
+bool	ms_export_variable_validate_arg(const char *arg);
 
 #endif

--- a/src/builtins/export/ms_export_variable_validate_arg.c
+++ b/src/builtins/export/ms_export_variable_validate_arg.c
@@ -1,0 +1,54 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_export_variable_validate_arg.c                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/27 10:43:26 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/03/27 11:04:30 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+#include <stdbool.h>
+#include <stdlib.h>
+
+static bool	ms_export_variable_validate_name(const char *name);
+
+bool	ms_export_variable_validate_arg(const char *arg)
+{
+	char	*name_end;
+	char	*name;
+	bool	ret;
+
+	name_end = ft_strchr(arg, '=');
+	if (name_end == NULL && name_end - arg >= 1 && name_end[-1] == '+')
+		name_end--;
+	else
+		name_end = ft_strchr(arg, '\0');
+	if (name_end == NULL || arg == name_end || ft_isdigit(arg[0]))
+		return (false);
+	name = ft_strndup(arg, name_end - arg);
+	if (name == NULL)
+		return (false);
+	ret = ms_export_variable_validate_name(name);
+	free(name);
+	return (ret);
+}
+
+static bool	ms_export_variable_validate_name(const char *name)
+{
+	char	*ptr;
+
+	if (name == NULL || name[0] == '\0' || ft_isdigit(name[0]))
+		return (false);
+	ptr = (char *)name;
+	while (*ptr != '\0')
+	{
+		if (!ft_isalnum(*ptr) && *ptr != '_')
+			return (false);
+		ptr++;
+	}
+	return (true);
+}

--- a/src/builtins/export/ms_export_variable_validate_arg.c
+++ b/src/builtins/export/ms_export_variable_validate_arg.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/27 10:43:26 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/27 11:04:30 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/27 11:43:09 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,10 +23,10 @@ bool	ms_export_variable_validate_arg(const char *arg)
 	bool	ret;
 
 	name_end = ft_strchr(arg, '=');
-	if (name_end == NULL && name_end - arg >= 1 && name_end[-1] == '+')
-		name_end--;
-	else
+	if (name_end == NULL)
 		name_end = ft_strchr(arg, '\0');
+	else if (name_end - arg >= 1 && name_end[-1] == '+')
+		name_end--;
 	if (name_end == NULL || arg == name_end || ft_isdigit(arg[0]))
 		return (false);
 	name = ft_strndup(arg, name_end - arg);

--- a/src/builtins/export/ms_export_variables.c
+++ b/src/builtins/export/ms_export_variables.c
@@ -6,12 +6,13 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/02 11:04:28 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/27 08:10:31 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/27 11:03:04 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libms.h"
 #include "libft.h"
+#include "export_internal.h"
 #include <stdlib.h>
 #include <stddef.h>
 
@@ -40,12 +41,12 @@ static int	ms_export_variable(const char *arg)
 {
 	char	*name_end;
 
+	if (ms_export_variable_validate_arg(arg) == false)
+		return (ms_export_error_not_a_valid_identifier(arg), 1);
 	name_end = ft_strchr(arg, '=');
 	if (name_end == NULL)
-		return (1);
-	if (name_end == NULL || arg == name_end)
-		return (ms_export_error_not_a_valid_identifier(arg), 1);
-	if (name_end[-1] == '+')
+		return (ms_export_set_variable(arg));
+	else if (name_end - arg >= 1 && name_end[-1] == '+')
 		return (ms_export_append_variable(arg));
 	else
 		return (ms_export_set_variable(arg));

--- a/src/builtins/export/ms_export_variables.c
+++ b/src/builtins/export/ms_export_variables.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/02 11:04:28 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/27 11:03:04 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/27 11:22:03 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,13 +27,17 @@ static int	ms_export_error_not_a_valid_identifier(const char *arg);
 int	ms_export_variables(const char **args)
 {
 	int		i;
+	bool	is_error;
 
 	i = 0;
+	is_error = false;
 	while (args[i] != NULL)
 	{
-		ms_export_variable(args[i]);
+		is_error |= ms_export_variable(args[i]);
 		i++;
 	}
+	if (is_error)
+		return (1);
 	return (0);
 }
 

--- a/tests/googletest/builtins/export/test_ms_builtin_export.cpp
+++ b/tests/googletest/builtins/export/test_ms_builtin_export.cpp
@@ -13,12 +13,13 @@ extern "C" {
 IoCapture *testBuiltinExport(const char *path, char *const *argv, char *const *envp)
 {
 	IoCapture *term = new IoCapture;
+	int status;
 
 	term->boot();
 	if (term->isCapturing())
 	{
-		ms_builtin_export(path, (char *const *)argv, envp);
-		exit(0);
+		status = ms_builtin_export(path, (char *const *)argv, envp);
+		exit(status);
 	}
 	term->exit();
 	return term;
@@ -103,5 +104,84 @@ TEST(ms_builtin_export, invalid_optin)
 	term = testBuiltinExport(NULL, (char *const*)args, NULL);
     EXPECT_EQ(term->getStdout(), expectStdout);
     EXPECT_EQ(term->getStderr(), expectStderr);
+	delete term;
+}
+
+TEST(ms_builtin_export, name_length_zero_error)
+{
+	std::string expectStderr;
+	std::string expectStdout;
+	int	expectStatus;
+	const char 	*args[] = {"export", "=321", "=", "", "+=", NULL};
+
+	expectStdout =
+		"";
+	expectStderr =
+		"minishell: export: `=321': not a valid identifier\n"
+		"minishell: export: `=': not a valid identifier\n"
+		"minishell: export: `': not a valid identifier\n"
+		"minishell: export: `+=': not a valid identifier\n"
+		;
+	expectStatus = 1;
+
+	// テスト
+	IoCapture 	*term;
+	term = testBuiltinExport(NULL, (char *const*)args, NULL);
+    EXPECT_EQ(term->getStdout(), expectStdout);
+    EXPECT_EQ(term->getStderr(), expectStderr);
+    EXPECT_EQ(term->getStatus(), expectStatus);
+	delete term;
+}
+
+TEST(ms_builtin_export, invalid_sign_error)
+{
+	std::string expectStderr;
+	std::string expectStdout;
+	int	expectStatus;
+	const char 	*args[] = {"export", "$=321", "!=", "#", "~+=", NULL};
+
+	expectStdout =
+		"";
+	expectStderr =
+		"minishell: export: `$=321': not a valid identifier\n"
+		"minishell: export: `!=': not a valid identifier\n"
+		"minishell: export: `#': not a valid identifier\n"
+		"minishell: export: `~+=': not a valid identifier\n"
+		;
+	expectStatus = 1;
+
+	// テスト
+	IoCapture 	*term;
+	term = testBuiltinExport(NULL, (char *const*)args, NULL);
+    EXPECT_EQ(term->getStdout(), expectStdout);
+    EXPECT_EQ(term->getStderr(), expectStderr);
+    EXPECT_EQ(term->getStatus(), expectStatus);
+	delete term;
+}
+
+// 名前の最初に数字が来る場合　エラー
+TEST(ms_builtin_export, first_number_error)
+{
+	std::string expectStderr;
+	std::string expectStdout;
+	int	expectStatus;
+	const char 	*args[] = {"export", "1asd", "3dfwe=", "123", "89+=a", NULL};
+
+	expectStdout =
+		"";
+	expectStderr =
+		"minishell: export: `1asd': not a valid identifier\n"
+		"minishell: export: `3dfwe=': not a valid identifier\n"
+		"minishell: export: `123': not a valid identifier\n"
+		"minishell: export: `89+=a': not a valid identifier\n"
+		;
+	expectStatus = 1;
+
+	// テスト
+	IoCapture 	*term;
+	term = testBuiltinExport(NULL, (char *const*)args, NULL);
+    EXPECT_EQ(term->getStdout(), expectStdout);
+    EXPECT_EQ(term->getStderr(), expectStderr);
+    EXPECT_EQ(term->getStatus(), expectStatus);
 	delete term;
 }


### PR DESCRIPTION

表題に対して修正しました！

また、テストを追加しました！
テストは、
 * 名前が空白の場合 ex. `export =value ""`
 * 名前に無効な記号が含まれているとき ex. `export #=value "&"`
 * 数字から始まるとき ex. `export =value "1abs"`
の3種類です！

