### PR TITLE
143 bug mnsh subshellの未実装

### DIFF
--- a/src/execution/ms_execute_compound_list.c
+++ b/src/execution/ms_execute_compound_list.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 19:22:22 by nyts              #+#    #+#             */
-/*   Updated: 2025/03/28 05:44:02 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/28 07:01:45 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,8 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+
+static void	ms_increase_mnsh_subshell(void);
 
 int	ms_execute_compound_lists(t_lsa_list **lists)
 {
@@ -28,10 +30,27 @@ int	ms_execute_compound_lists(t_lsa_list **lists)
 		return (1);
 	if (pid == 0)
 	{
+		if (ms_is_mnsh_subshell_var_enabled())
+			ms_increase_mnsh_subshell();
 		ret = ms_execute_lists(lists);
 		ret = ms_add_meta(ret, IS_CHILD);
 	}
 	else
 		waitpid(pid, &ret, 0);
 	return (ret);
+}
+
+static void	ms_increase_mnsh_subshell(void)
+{
+	int		subshell;
+	char	*subshell_str;
+
+	subshell_str = ms_getenv("MNSH_SUBSHELL");
+	if (subshell_str == NULL)
+		return ;
+	subshell = ms_shell_atoi(subshell_str);
+	subshell++;
+	subshell_str = ft_itoa(subshell);
+	ms_setenv("MNSH_SUBSHELL", subshell_str, 1);
+	free(subshell_str);
 }

--- a/src/execution/ms_execute_compound_list.c
+++ b/src/execution/ms_execute_compound_list.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ms_execute_compound_list.c                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nyts <nyts@student.42.fr>                  +#+  +:+       +#+        */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 19:22:22 by nyts              #+#    #+#             */
-/*   Updated: 2025/03/04 19:22:23 by nyts             ###   ########.fr       */
+/*   Updated: 2025/03/28 05:44:02 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,8 +29,9 @@ int	ms_execute_compound_lists(t_lsa_list **lists)
 	if (pid == 0)
 	{
 		ret = ms_execute_lists(lists);
-		exit(ret);
+		ret = ms_add_meta(ret, IS_CHILD);
 	}
-	waitpid(pid, &ret, 0);
+	else
+		waitpid(pid, &ret, 0);
 	return (ret);
 }

--- a/src/execution/ms_execute_lists.c
+++ b/src/execution/ms_execute_lists.c
@@ -3,14 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   ms_execute_lists.c                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rnakatan <rnakatan@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/23 02:29:32 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/01/26 21:33:03 by rnakatan         ###   ########.fr       */
+/*   Updated: 2025/03/28 05:45:12 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "execution.h"
+#include "libms.h"
 
 int	ms_execute_lists(t_lsa_list **lists)
 {
@@ -19,7 +20,7 @@ int	ms_execute_lists(t_lsa_list **lists)
 
 	ret = 0;
 	i = 0;
-	while (lists[i])
+	while (lists[i] && ms_has_meta(ret, IS_CHILD) == false)
 	{
 		if (lists[i]->type == LSA_LIST_AND && ret != 0)
 			break ;

--- a/src/include/libms.h
+++ b/src/include/libms.h
@@ -69,6 +69,7 @@ int				ms_add_string_to_lst(t_list **file_list_lst, char *filename);
 int				ms_get_status_from_meta(int status);
 int				ms_shell_atoi(const char *str);
 bool			ms_isadir(const char *path);
+void			ms_update_environs(void);
 
 // environment variable
 char			*ms_getenv(const char *name);
@@ -100,5 +101,9 @@ void			ms_set_exports(t_list *exports);
 void			ms_clear_exports(void);
 int				ms_add_export(const char *name);
 t_list			*ms_find_export(const char *name);
+
+// mnsh_subshell
+bool			ms_is_mnsh_subshell_var_enabled(void);
+void			ms_set_mnsh_subshell_var_enabled(bool enable);
 
 #endif

--- a/src/input/ms_input.c
+++ b/src/input/ms_input.c
@@ -33,6 +33,7 @@ int	ms_input(t_minishell mnsh)
 	status = 0;
 	while (ms_is_loop(status))
 	{
+		ms_update_environs();
 		line = ms_get_user_input(mnsh);
 		if (line == NULL)
 			break ;

--- a/src/input/ms_update_environs.c
+++ b/src/input/ms_update_environs.c
@@ -1,0 +1,19 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_update_environs.c                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/28 06:53:31 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/03/28 06:57:09 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libms.h"
+
+void	ms_update_environs(void)
+{
+	if (ms_getenv("MNSH_SUBSHELL") == NULL)
+		ms_set_mnsh_subshell_var_enabled(false);
+}

--- a/src/libms/ms_mnsh_subshell.c
+++ b/src/libms/ms_mnsh_subshell.c
@@ -1,0 +1,25 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_mnsh_subshell.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/28 06:38:24 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/03/28 06:57:38 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <stdbool.h>
+
+static bool	g_mnsh_subshell_var_enabled = true;
+
+bool	ms_is_mnsh_subshell_var_enabled(void)
+{
+	return (g_mnsh_subshell_var_enabled);
+}
+
+void	ms_set_mnsh_subshell_var_enabled(bool enable)
+{
+	g_mnsh_subshell_var_enabled = enable;
+}

--- a/src/setup/ms_setup_variable.c
+++ b/src/setup/ms_setup_variable.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/18 17:29:38 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/25 08:35:59 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/28 07:21:30 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,6 @@ static void	ms_setup_only_interactive_var(void)
 	ms_setenv("TMPDIR", "/tmp", 0);
 	ms_setenv("PS1", "minishell $ ", 0);
 	ms_setenv("PS2", "> ", 0);
-	ms_setenv("MNSH_SUBSHELL", "0", 0);
 }
 
 static void	ms_setup_common_variable(void)
@@ -52,6 +51,7 @@ static void	ms_setup_common_variable(void)
 	ms_setenv("?", "0", 0);
 	free(cwd);
 	ms_setup_shlvl();
+	ms_setenv("MNSH_SUBSHELL", "0", 0);
 }
 
 static void	ms_setup_shlvl(void)

--- a/tests/pytest/general/test_variable/test_MNSH_SUBSHELL_basic.sh
+++ b/tests/pytest/general/test_variable/test_MNSH_SUBSHELL_basic.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# テスト用の設定の読み込み
+cd "$(dirname $0)"
+. "../../test_prepare.sh"
+
+# テスト
+LEAKCHECK="valgrind -q --error-exitcode=12 --leak-check=full"
+$LEAKCHECK $PROG << "EOF"
+MNSH_SUBSHELL=0
+( ( echo $MNSH_SUBSHELL && MNSH_SUBSHELL=4 && ( echo $MNSH_SUBSHELL ) ) )
+echo $?
+EOF

--- a/tests/pytest/general/test_variable/test_MNSH_SUBSHELL_overflow.sh
+++ b/tests/pytest/general/test_variable/test_MNSH_SUBSHELL_overflow.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# テスト用の設定の読み込み
+cd "$(dirname $0)"
+. "../../test_prepare.sh"
+
+# テスト
+LEAKCHECK="valgrind -q --error-exitcode=12 --leak-check=full"
+$LEAKCHECK $PROG << "EOF"
+MNSH_SUBSHELL=2147483647
+( echo $MNSH_SUBSHELL )
+echo $?
+EOF

--- a/tests/pytest/general/test_variable/test_MNSH_SUBSHELL_unset.sh
+++ b/tests/pytest/general/test_variable/test_MNSH_SUBSHELL_unset.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# テスト用の設定の読み込み
+cd "$(dirname $0)"
+. "../../test_prepare.sh"
+
+# テスト
+LEAKCHECK="valgrind -q --error-exitcode=12 --leak-check=full"
+$LEAKCHECK $PROG << "EOF"
+unset MNSH_SUBSHELL
+echo $MNSH_SUBSHELL
+MNSH_SUBSHELL=3
+( echo $MNSH_SUBSHELL )
+echo $?
+EOF

--- a/tests/pytest/general/test_variable/test_variable.py
+++ b/tests/pytest/general/test_variable/test_variable.py
@@ -51,3 +51,26 @@ def test_HISTCMD_unset():
             "3\n"
             "3\n"),
         expected_stderr = "")
+
+def test_MNSH_SUBSHELL_overflow():
+    script_tester.test("general/test_variable/test_MNSH_SUBSHELL_overflow.sh",
+        expected_stdout = (
+            "-2147483648\n"
+            "0\n"),
+        expected_stderr = "")
+
+def test_MNSH_SUBSHELL_unset():
+    script_tester.test("general/test_variable/test_MNSH_SUBSHELL_unset.sh",
+        expected_stdout = (
+            "\n"
+            "3\n"
+            "0\n"),
+        expected_stderr = "")
+
+def test_MNSH_SUBSHELL_basic():
+    script_tester.test("general/test_variable/test_MNSH_SUBSHELL_basic.sh",
+        expected_stdout = (
+            "2\n"
+            "5\n"
+            "0\n"),
+        expected_stderr = "")


### PR DESCRIPTION
* MNSH_SUBHSHELLが加算されるように変更しました。
* 初期化位置が問題だったため修正しました。
* MNSH_SUBSHELLが一度でもunsetされたら、この挙動にならないようにしました。
* テストコードの追加をしました。overflow unset basicな使い方

**テストコードサンプル**
### 加算テスト
* 初期値が同じであること。
* ２つかっこで２つ加算されること。
* 同じリスト内で値が変わらないこと。
* １つかっこで１つ加算されること。

**minishell**
```sh
echo $MNSH_SUBSHELL && ( ( echo $MNSH_SUBSHELL && echo $MNSH_SUBSHELL && ( echo $MNSH_SUBSHELL ) ) )
```
**bash**
```sh
echo $BASH_SUBSHELL && ( ( echo $BASH_SUBSHELL && echo $BASH_SUBSHELL && ( echo $BASH_SUBSHELL ) ) )
```

### unsetテスト
* 初期値の確認
* unsetされた状態では何も表示されないこと
* 値を設定し直して、１つかっこで移動しても加算されないこと。

**minishell**
```sh
echo $MNSH_SUBSHELL && unset MNSH_SUBSHELL && ( echo $MNSH_SUBSHELL && MNS_SUBSHELL=0 && ( echo $MNSH_SUBSHELL ) )
```
**bash**
```sh
echo $BASH_SUBSHELL && unset BASH_SUBSHELL && ( echo $BASH_SUBSHELL && MNS_SUBSHELL=0 && ( echo $BASH_SUBSHELL ) )
```