### PR TITLE
139-bug-コピペでコマンドを張り付けたときに１行ずつ実行されない

### DIFF
--- a/src/finalize/ms_cleanup_and_exit.c
+++ b/src/finalize/ms_cleanup_and_exit.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/15 13:46:44 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/25 05:47:00 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/28 08:10:19 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 #include "libms.h"
 #include "history.h"
 #include "builtin_internal.h"
+#include "readline.h"
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -21,6 +22,7 @@ static void	ms_export_history(void);
 
 void	ms_cleanup_and_exit(int status)
 {
+	ms_clear_readline_buffer();
 	if (ms_is_interactive() && ! ms_has_meta(status, IS_CHILD))
 	{
 		printf("exit\n");

--- a/src/include/readline.h
+++ b/src/include/readline.h
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 10:09:32 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/01/30 19:29:48 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/28 08:09:49 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,5 +18,6 @@
 char	*ms_readline(const char *prompt);
 int		ms_setup_readline_handler(void);
 int		ms_setup_readline_behavior(void);
+void	ms_clear_readline_buffer(void);
 
 #endif

--- a/src/readline/ms_readline.c
+++ b/src/readline/ms_readline.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/20 08:38:39 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/02/11 07:36:55 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/03/28 08:14:33 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,11 +14,61 @@
 #include "setup.h"
 #include <readline/readline.h>
 #include <unistd.h>
+#include <stdlib.h>
+
+static char	*g_readline_buffer = NULL;
+
+static char	*ms_cut_and_replace(char **buffer);
+static void	ms_clear_str(char **buffer);
 
 char	*ms_readline(const char *prompt)
 {
-	if (ms_is_interactive())
-		return (readline(prompt));
+	if (g_readline_buffer != NULL)
+		;
+	else if (ms_is_interactive())
+		g_readline_buffer = readline(prompt);
 	else
-		return (readline(NULL));
+		g_readline_buffer = readline(NULL);
+	return (ms_cut_and_replace(&g_readline_buffer));
+}
+
+void	ms_clear_readline_buffer(void)
+{
+	ms_clear_str(&g_readline_buffer);
+}
+
+static void	ms_clear_str(char **str)
+{
+	if (str == NULL)
+		return ;
+	free(*str);
+	*str = NULL;
+	return ;
+}
+
+static char	*ms_cut_and_replace(char **buffer)
+{
+	char	*cut_end;
+	char	*line;
+	char	*new_buffer;
+
+	if (*buffer == NULL)
+		return (NULL);
+	cut_end = ft_strchr(*buffer, '\n');
+	if (cut_end == NULL)
+	{
+		line = *buffer;
+		*buffer = NULL;
+		return (line);
+	}
+	line = ft_strndup(*buffer, cut_end - *buffer);
+	if (line == NULL)
+		return (ms_clear_str(buffer), NULL);
+	cut_end++;
+	if (*cut_end == '\0')
+		return (ms_clear_str(buffer), line);
+	new_buffer = ft_strdup(cut_end);
+	free(*buffer);
+	*buffer = new_buffer;
+	return (line);
 }


### PR DESCRIPTION

この問題に対応しました。

readline関数が１度に複数行読んだときは、一行ずつ返すように処理するようにしました。

また、リーク防止のために、ms_clear_readline_buffer関数を定義しました。

この問題はコードでテストは難しいと感じたため、テストは作成していません。

例えば以下のようなコマンドをコピーして貼り付けすることでチェックできます。
```sh
echo this is test '!'
echo do you watch me?
echo start cat command '!!!' please, push Ctrl + D for end.
cat
echo cat end '!!' yeah '!!!'
```