### PR TITLE
126 bug 変数の空文字列設定がされていない

### DIFF
--- a/src/execution/ms_run_assignment_variables.c
+++ b/src/execution/ms_run_assignment_variables.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ms_run_assignment_variables.c                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rnakatan <rnakatan@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/08 19:21:41 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/03/08 19:21:42 by rnakatan         ###   ########.fr       */
+/*   Updated: 2025/03/28 10:02:09 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,6 +50,8 @@ static char	*ms_expand_assignment_variables(t_lsa_word_list *word_list)
 	char	**expanded_texts;
 	char	*expanded_text;
 
+	if (word_list->word_list == NULL)
+		return (ft_strdup(""));
 	expanded_texts = ms_expansion(word_list);
 	if (expanded_texts == NULL)
 		return (NULL);

--- a/src/syntax_analyze/parse/nonterminal/ms_parse_assignment_word.c
+++ b/src/syntax_analyze/parse/nonterminal/ms_parse_assignment_word.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ms_parse_assignment_word.c                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rnakatan <rnakatan@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/02 21:19:49 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/03/12 03:38:43 by rnakatan         ###   ########.fr       */
+/*   Updated: 2025/03/28 09:52:44 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,7 +40,7 @@ static const t_syntax_rule	*g_ms_assignment_word_rule_list[] = {
 	false,
 	true}},
 	(t_syntax_rule[]){{
-	EBNF_ONE,
+	EBNF_OPTION,
 	(t_parse_func *)g_ms_assignment_word_value_funcs,
 	false,
 	true}},

--- a/tests/pytest/variable_expansion/test_assignment.sh
+++ b/tests/pytest/variable_expansion/test_assignment.sh
@@ -16,4 +16,6 @@ echo $HOGE
 HOGE=hoge
 HOGE=$HOGE$HOGE$HOGE
 echo 'assignment($HOGE=hoge) self three time. '$HOGE
+HOGE=
+echo 'assignment($HOGE=) empty. "'$HOGE'"'
 EOF

--- a/tests/pytest/variable_expansion/test_variable_expansion.py
+++ b/tests/pytest/variable_expansion/test_variable_expansion.py
@@ -15,8 +15,8 @@ def test_assignment():
 	result2 = "value  include   space" + "\n"
 	result3 = "join double quoted & non_quoted & single quoted" + "\n"
 	result4 = "assignment($HOGE=hoge) self three time. hogehogehoge" + "\n"
+	result5 = "assignment($HOGE=) empty. \"\"" + "\n"
 	script_tester.test("variable_expansion/test_assignment.sh",
-		expected_stdout = result + result2 + result3 + result4,
+		expected_stdout = result + result2 + result3 + result4 + result5,
 		expected_stderr = ""
 	)
-	


### PR DESCRIPTION
`A=`のようにvalueがない変数代入も実行できるようにしました。
テストを追加しました。

構文解析の部分と、実行部分を変更しました。
割と無理やり変更したので、問題があるかもしれません。
