### PR TITLE
157 bug リスト 時に終了ステータスが渡されていない

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,8 @@
 		"functional": "cpp",
 		"semantic_analyze_type.h": "c",
 		"lexical_analyze.h": "c",
-		"ms_execute_pipeline.h": "c"
+		"ms_execute_pipeline.h": "c",
+		"readline.h": "c"
 	},
 	"editor.indentSize": "tabSize"
 }

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,5 @@ test_pytest:
 	bash tests/pytest/run_test.sh
 
 test_norm:
-	! (bash -c "norminette src" | grep -v OK) && echo "Norminette OK" || false
+	test -f /usr/local/bin/norminette || (echo "Norminette not found, please install it" && exit 1)
+	! (/usr/local/bin/norminette src | grep -v OK) && echo "Norminette OK" || false

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ test_pytest:
 	bash tests/pytest/run_test.sh
 
 test_norm:
-	! (norminette src | grep -v OK) && echo "Norminette OK" || false
+	! (bash -c "norminette src" | grep -v OK) && echo "Norminette OK" || false

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:22.04 AS base
 
+ARG NORM_VERSION=3.3.51
+
 RUN <<EOF
 apt update -y
 apt upgrade -y
@@ -9,7 +11,7 @@ apt install -y \
 	python3-pip \
 	git \
 	libreadline-dev
-pip install pytest
+pip install pytest norminette==${NORM_VERSION}
 EOF
 
 # Installing
@@ -56,13 +58,9 @@ WORKDIR /home/minishell
 # デバッグ用の環境
 FROM final AS debug
 
-ARG NORM_VERSION=3.3.51
-
 RUN <<EOF
 apt-get update -y
 apt-get upgrade -y
 apt-get install -y \
 	lldb
-pip install \
-	norminette==${NORM_VERSION}
 EOF

--- a/src/include/libms.h
+++ b/src/include/libms.h
@@ -65,6 +65,8 @@ int				ms_add_meta(int status, int meta);
 bool			ms_has_meta(int status, int meta);
 int				ms_get_meta(int status);
 
+int				ms_set_exit_status(int ret);
+
 int				ms_add_string_to_lst(t_list **file_list_lst, char *filename);
 int				ms_get_status_from_meta(int status);
 int				ms_shell_atoi(const char *str);

--- a/src/input/ms_input.c
+++ b/src/input/ms_input.c
@@ -45,24 +45,17 @@ int	ms_input(t_minishell mnsh)
 
 static int	ms_run_command(char *line)
 {
-	int		status;
-	char	*stat_str;
+	int		ret;
 
-	status = 0;
+	ret = 0;
 	if (! g_rl_is_sigint)
 	{
 		ms_add_mnsh_history(line);
-		status = ms_execution(line);
-		stat_str = ft_itoa(ms_get_status_from_meta(status));
-		ms_setenv("?", stat_str, 1);
-		free(stat_str);
+		ret = ms_execution(line);
 	}
 	if (g_rl_is_sigint)
-		status = 128 + SIGINT + ms_get_meta(status);
-	stat_str = ft_itoa(ms_get_status_from_meta(status));
-	ms_setenv("?", stat_str, 1);
-	free(stat_str);
-	return (status);
+		ms_set_exit_status(ret);
+	return (ret);
 }
 
 static char	*ms_get_user_input(t_minishell mnsh)

--- a/src/libms/ms_set_exit_status.c
+++ b/src/libms/ms_set_exit_status.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ms_set_exit_status.c                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rnakatan <rnakatan@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/29 12:14:43 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/03/29 12:38:02 by rnakatan         ###   ########.fr       */
+/*   Updated: 2025/04/01 08:57:49 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,6 @@
  * set minishell's exit status.
  * -> insert $?
  */
-
 
 int	ms_set_exit_status(int ret)
 {

--- a/src/libms/ms_set_exit_status.c
+++ b/src/libms/ms_set_exit_status.c
@@ -1,31 +1,37 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ms_execute_list.c                                  :+:      :+:    :+:   */
+/*   ms_set_exit_status.c                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: rnakatan <rnakatan@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/01/23 02:37:50 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/03/29 12:39:15 by rnakatan         ###   ########.fr       */
+/*   Created: 2025/03/29 12:14:43 by rnakatan          #+#    #+#             */
+/*   Updated: 2025/03/29 12:38:02 by rnakatan         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "execution.h"
-#include "libms.h"
-#include <readline.h>
 #include <signal.h>
+#include <readline.h>
 #include <stdlib.h>
+#include "libft.h"
+#include "libms.h"
 
-int	ms_execute_list(t_lsa_list *list)
+/**
+ * set minishell's exit status.
+ * -> insert $?
+ */
+
+
+int	ms_set_exit_status(int ret)
 {
-	int	ret;
+	char	*stat_str;
+	int		status;
 
-	if (list->pipeline)
-	{
-		ret = ms_execute_pipeline(list->pipeline);
-		ms_set_exit_status(ret);
-	}
-	else
-		ret = ms_execute_compound_lists(list->compound_list);
-	return (ret);
+	status = ms_get_status_from_meta(ret);
+	if (g_rl_is_sigint)
+		status += 128 + SIGINT;
+	stat_str = ft_itoa(status);
+	ms_setenv("?", stat_str, 1);
+	free(stat_str);
+	return (0);
 }

--- a/tests/googletest/Makefile
+++ b/tests/googletest/Makefile
@@ -8,7 +8,7 @@ CXXFLAGS = -Wall -Wextra -Werror -MMD -MP -g -O0 -I $(SRC_DIR)/include -I includ
 CC       = cc
 CFLAGS   = $(CXXFLAGS)
 LDFLAGS  = -L.
-LDLIBS   = -lmsh -pthread -lgtest_main -lgtest
+LDLIBS   = -lmsh -pthread -lgtest_main -lgtest -lreadline
 
 CACHEDIR = cache
 

--- a/tests/pytest/pipeline/list/test_list.py
+++ b/tests/pytest/pipeline/list/test_list.py
@@ -1,0 +1,13 @@
+import script_tester
+import pytest
+import os
+
+dirname = "pipeline/list/"
+
+def test_list_status():
+	result = "0\n127\n"
+	script_tester.test("pipeline/list/test_list_status.sh",
+		expected_stdout = result,
+		expected_stderr = "minishell: not_such_command: command not found\n"
+    					"minishell: ahog: command not found\n"
+	)

--- a/tests/pytest/pipeline/list/test_list_status.sh
+++ b/tests/pytest/pipeline/list/test_list_status.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# テスト用の設定の読み込み
+cd "$(dirname $0)"
+. "../../test_prepare.sh"
+
+# テスト
+LEAKCHECK="valgrind -q --error-exitcode=12 --leak-check=full"
+$LEAKCHECK $PROG << "EOF"
+not_such_command
+echo -n && echo $?
+ahog -n || echo $?
+EOF


### PR DESCRIPTION
体調戻ってからレビューお願いします！！！　休養だいじ！！Zzz

## issueに表記のbugの発生理由
- 終了ステータス($?)の設定を入力を全て処理したあとに行っていた
  ->リスト記号(`&&` `||`)を用いた際に次のリストに終了ステータスが渡っていなかった。

## 修正内容
- 終了ステータスを取得する場所を、各リストの処理終了時点に変更した。

## 書いたテストの内容
- `||`と`&&`についてそれぞれ終了ステータスが渡るかどうか

## issue以外に解決したバグ
ここを治したときにlist token(`||`)を使った際に子プロセスが終了していないバグ
-> issueなどにあげる予定ありましたら、ご確認お願いします