### PR TITLE
208 bug 非表示文字はcdのエラー時にエスケープした状態で表示すること

### DIFF
--- a/src/builtins/cd/ms_perror_cd.c
+++ b/src/builtins/cd/ms_perror_cd.c
@@ -13,8 +13,44 @@
 #include "libms.h"
 #include <errno.h>
 #include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
 
-void	ms_perror_cd(const char *type)
+static bool	ms_is_should_escape(const char *path);
+
+void	ms_perror_cd(const char *path)
 {
-	ms_perror_cmd2("cd", type, strerror(errno));
+	char	*escaped_path;
+	char	*path_string;
+
+	if (ms_is_should_escape(path) == false)
+		ms_perror_cmd2("cd", path, strerror(errno));
+	else
+	{
+		path_string = ft_strdup("$'");
+		if (path_string == NULL)
+			return ;
+		escaped_path = ms_dup_escapedstr(path);
+		if (escaped_path != NULL)
+		{
+			if (ms_replace_joined_str(&path_string, escaped_path) != NULL)
+			{
+				if (ms_replace_joined_str(&path_string, "'") != NULL)
+					ms_perror_cmd2("cd", path_string, strerror(errno));
+			}
+			free(escaped_path);
+		}
+		free(path_string);
+	}
+}
+
+static bool	ms_is_should_escape(const char *path)
+{
+	while (*path != '\0')
+	{
+		if (ft_isprint(*path) == 0)
+			return (true);
+		path++;
+	}
+	return (false);
 }

--- a/src/include/libms.h
+++ b/src/include/libms.h
@@ -72,6 +72,7 @@ int				ms_get_status_from_meta(int status);
 int				ms_shell_atoi(const char *str);
 bool			ms_isadir(const char *path);
 void			ms_update_environs(void);
+char			*ms_dup_escapedstr(const char *str);
 
 // environment variable
 char			*ms_getenv(const char *name);

--- a/src/libms/ms_dup_escapedstr.c
+++ b/src/libms/ms_dup_escapedstr.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/02 14:42:33 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/04/02 17:46:02 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/05 06:04:06 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,7 +51,7 @@ char	*ms_dup_escapedstr(const char *str)
 static char	*ms_toescapedstr(char dest[11], const int chr)
 {
 	const char	*escaped_str = "\a\b\e\f\n\r\t\v\\'";
-	const char	*escaped_map = "\\a\\b\\e\\f\\n\\r\\t\\v\\\\\\'";
+	const char	*escaped_map = "\\a\\b\\E\\f\\n\\r\\t\\v\\\\\\'";
 	char		*escaped_ptr;
 
 	escaped_ptr = ft_strchr(escaped_str, chr);

--- a/src/libms/ms_dup_escapedstr.c
+++ b/src/libms/ms_dup_escapedstr.c
@@ -1,0 +1,91 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_dup_escapedstr.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/02 14:42:33 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/04/02 17:46:02 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+#include <stdlib.h>
+
+static char		*ms_toescapedstr(char dest[11], const int chr);
+static size_t	ms_escapedstrlen(const char *str);
+
+/**
+ * convert string includes special characters to escaped string.
+ * use this escape list:
+ * 		\a \b \e \f \n \r \t \v \ '
+ * if the string includes non-printable characters and not included above
+ * escape list, it is converted to octal: e.g. \337
+ */
+char	*ms_dup_escapedstr(const char *str)
+{
+	char	*escaped;
+	char	*escaped_ptr;
+	char	escaped_buf[11];
+	size_t	escaped_len;
+	size_t	catsize;
+
+	escaped_len = ms_escapedstrlen(str);
+	escaped = malloc((escaped_len + 1) * sizeof(char));
+	if (escaped == NULL)
+		return (NULL);
+	escaped_ptr = escaped;
+	escaped[0] = '\0';
+	while (*str != '\0')
+	{
+		ms_toescapedstr(escaped_buf, *str);
+		catsize = ft_strlcat(escaped, escaped_buf, escaped_len + 1);
+		escaped_len -= catsize;
+		escaped += catsize;
+		str += 1;
+	}
+	return (escaped_ptr);
+}
+
+static char	*ms_toescapedstr(char dest[11], const int chr)
+{
+	const char	*escaped_str = "\a\b\e\f\n\r\t\v\\'";
+	const char	*escaped_map = "\\a\\b\\e\\f\\n\\r\\t\\v\\\\\\'";
+	char		*escaped_ptr;
+
+	escaped_ptr = ft_strchr(escaped_str, chr);
+	if (escaped_ptr != NULL)
+		ft_strlcpy(dest, escaped_map + (escaped_ptr - escaped_str) * 2, 3);
+	else if (ft_isprint(chr))
+	{
+		ft_strlcpy(dest, "x", 11);
+		dest[0] = chr;
+	}
+	else
+	{
+		ft_strlcpy(dest, "\\000", 11);
+		dest[3] = '0' + (unsigned char)chr % 8;
+		dest[2] = '0' + ((unsigned char)chr >> 3) % 8;
+		dest[1] = '0' + ((unsigned char)chr >> 6) % 8;
+	}
+	return (dest);
+}
+
+static size_t	ms_escapedstrlen(const char *str)
+{
+	size_t	len;
+
+	len = 0;
+	while (*str != '\0')
+	{
+		if (ft_includes(*str, "\a\b\e\f\n\r\t\v\\\'"))
+			len += 2;
+		else if (ft_isprint(*str))
+			len++;
+		else
+			len += 4;
+		str++;
+	}
+	return (len);
+}

--- a/tests/googletest/libms/test_ms_dup_escapedstr.cpp
+++ b/tests/googletest/libms/test_ms_dup_escapedstr.cpp
@@ -25,7 +25,7 @@ TEST(ms_dup_escapedstr, will_escaped_character)
 	escaped = ms_dup_escapedstr("\a \b \e \f \n \r \t \v \\ '");
 	if (escaped == NULL)
 		FAIL();
-	EXPECT_STREQ(escaped, "\\a \\b \\e \\f \\n \\r \\t \\v \\\\ \\'");
+	EXPECT_STREQ(escaped, "\\a \\b \\E \\f \\n \\r \\t \\v \\\\ \\'");
 	free(escaped);
 }
 

--- a/tests/googletest/libms/test_ms_dup_escapedstr.cpp
+++ b/tests/googletest/libms/test_ms_dup_escapedstr.cpp
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+    #include "libms.h"
+	#include <stdlib.h>
+};
+
+// 普通の文字はそのまま出力されること
+TEST(ms_dup_escapedstr, basic)
+{
+	char	*escaped;
+
+	escaped = ms_dup_escapedstr("hello");
+	if (escaped == NULL)
+		FAIL();
+	EXPECT_STREQ(escaped, "hello");
+	free(escaped);
+}
+
+// エスケープ文字はエスケープされて出力されること
+TEST(ms_dup_escapedstr, will_escaped_character)
+{
+	char	*escaped;
+
+	escaped = ms_dup_escapedstr("\a \b \e \f \n \r \t \v \\ '");
+	if (escaped == NULL)
+		FAIL();
+	EXPECT_STREQ(escaped, "\\a \\b \\e \\f \\n \\r \\t \\v \\\\ \\'");
+	free(escaped);
+}
+
+// 出力できない数値は８進数で出力されること
+TEST(ms_dup_escapedstr, will_escape_with_octal)
+{
+	char	*escaped;
+
+	escaped = ms_dup_escapedstr("\01 \020 \x7f \x8f \xff");
+	if (escaped == NULL)
+		FAIL();
+	EXPECT_STREQ(escaped, "\\001 \\020 \\177 \\217 \\377");
+	free(escaped);
+}

--- a/tests/pytest/builtin/cd/test_errors/escape_string.sh
+++ b/tests/pytest/builtin/cd/test_errors/escape_string.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# テスト用の設定の読み込み
+cd "$(dirname $0)"
+. "../../../test_prepare.sh"
+
+# ディレクトリの作成
+mkdir -p tmp
+
+# テスト
+# PROG="bash"
+export HOGE1=$'\a \b \e \f \n \r \t \v \\ \'' HOGE2=$'\001 \020 \x7f \x8f \xff'
+LEAKCHECK="valgrind -q --error-exitcode=12 --leak-check=full"
+$LEAKCHECK $PROG << "EOF"
+cd "$HOGE1"
+cd "$HOGE2"
+EOF
+
+# 後始末
+rm -rf tmp

--- a/tests/pytest/builtin/cd/test_errors/test_errors.py
+++ b/tests/pytest/builtin/cd/test_errors/test_errors.py
@@ -38,3 +38,11 @@ def test_getcwd_error():
         expected_stderr = (
             "cd: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory\n"
             ))
+
+def test_escape_string():
+    script_tester.test("builtin/cd/test_errors/escape_string.sh",
+        expected_stdout = "",
+        expected_stderr = (
+            "minishell: cd: $'\\a \\b \\E \\f \\n \\r \\t \\v \\\\ \\\'': No such file or directory\n"
+            "minishell: cd: $'\\001 \\020 \\177 \\217 \\377': No such file or directory\n"
+            ))


### PR DESCRIPTION
表題の通り修正しました。

bashで
```
export HOGE=$'\n'
```
としたあと、

minishellを起動して、
```
cd "$HOGE"
```
のようにすることで動作確認できます。