### PR TITLE
227-ブロッキング中にsigquitが来るとコアダンプの生成 

### DIFF
--- a/src/execution/ms_execute_compound_list.c
+++ b/src/execution/ms_execute_compound_list.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 19:22:22 by nyts              #+#    #+#             */
-/*   Updated: 2025/03/28 07:01:45 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/06 10:16:44 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,7 @@ int	ms_execute_compound_lists(t_lsa_list **lists)
 		return (1);
 	if (pid == 0)
 	{
+		ms_set_default_signal();;
 		if (ms_is_mnsh_subshell_var_enabled())
 			ms_increase_mnsh_subshell();
 		ret = ms_execute_lists(lists);

--- a/src/execution/ms_execute_compound_list.c
+++ b/src/execution/ms_execute_compound_list.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 19:22:22 by nyts              #+#    #+#             */
-/*   Updated: 2025/04/06 10:16:44 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/06 10:58:14 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,7 @@ int	ms_execute_compound_lists(t_lsa_list **lists)
 		return (1);
 	if (pid == 0)
 	{
-		ms_set_default_signal();;
+		ms_set_default_signal();
 		if (ms_is_mnsh_subshell_var_enabled())
 			ms_increase_mnsh_subshell();
 		ret = ms_execute_lists(lists);

--- a/src/execution/ms_run_pipeline.c
+++ b/src/execution/ms_run_pipeline.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/10 18:18:04 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/03/23 12:00:58 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/06 10:26:30 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,6 +61,7 @@ static int	ms_run_pipeline_command(t_lsa_pipeline *pipeline, int index,
 	pid_list[index] = fork();
 	if (pid_list[index] == 0)
 	{
+		ms_set_default_signal();
 		ret = ms_run_pipeline_child(pipeline, index, pipe_fds);
 		return (free(pid_list), ret);
 	}
@@ -128,7 +129,11 @@ static int	ms_wait_for_children(pid_t *pid_list, int cmd_count)
 		if (WIFEXITED(status))
 			status = WEXITSTATUS(status);
 		else if (WIFSIGNALED(status))
+		{
+			if (pid == pid_list[cmd_count - 1] && WCOREDUMP(status))
+				ft_putstr_fd("Quit (core dumped)\n", 2);
 			status = 128 + WTERMSIG(status);
+		}
 		i++;
 	}
 	return (status);

--- a/src/execution/signal/ms_set_default_signal.c
+++ b/src/execution/signal/ms_set_default_signal.c
@@ -1,0 +1,26 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_set_default_signal.c                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/06 10:13:54 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/04/06 10:30:19 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <signal.h>
+#include <stddef.h>
+#include "libft.h"
+
+void	ms_set_default_signal(void)
+{
+	struct sigaction	act;
+
+	ft_bzero(&act, sizeof(act));
+	act.sa_handler = SIG_DFL;
+	sigemptyset(&act.sa_mask);
+	sigaction(SIGINT, &act, NULL);
+	sigaction(SIGQUIT, &act, NULL);
+}

--- a/src/include/execution.h
+++ b/src/include/execution.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execution.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nyts <nyts@student.42.fr>                  +#+  +:+       +#+        */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 19:14:35 by nyts              #+#    #+#             */
-/*   Updated: 2025/03/04 19:14:36 by nyts             ###   ########.fr       */
+/*   Updated: 2025/04/06 10:16:59 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,8 @@ char			**ms_expansion(t_lsa_word_list *lsa_word_list);
 
 int				ms_run_assignment_variables(t_lsa_assignment **assignments);
 int				ms_run_redirects(t_lsa_redirection **redirects);
+
+void			ms_set_default_signal(void);
 
 t_syntax_node	*ms_parameter_expansion(t_syntax_node *word_list);
 t_syntax_node	*ms_execution_tilde_expantion(t_syntax_node *word_list);


### PR DESCRIPTION
### 概要
表題の通りコアダンプの生成について処理を作成しました。

実際には、エラーメッセージを出しているだけになっています。

変更内容としては、fork後にSIG_DFLを設定して、WCOREDUMPでパイプラインの最後のコマンドに対してSIGQUITが送信されたことを検知したときのみ表示するようにしました。

### **コアダンプファイルについて**
おそらくコアダンプファイルは生成されないと思います。以下理由。
`man 5 core`より、`/proc/sys/kernel/core_pattern`に従って保存されることを確認し、apportコマンドを使って、`/var/crash`かカレントディレクトリに保存されるとされていました(`man apport-cli`)が、確認できませんでした。
また、`ulimit -c`が悪さしている可能性があるかもしれませんが、４２の環境では管理者権限がなく上手く確認できず、dockerの仮想環境内では、カレントディレクトリには保存されていることが確認できず、ルートでも`/var/crash`にはアクセス権がありませんでした。

よって、おそらくコアダンプファイルは生成されないものと思います。