### PR TITLE
230 segv を入力したときにcrash

### DIFF
--- a/src/execution/expantion/ms_pathname_expantion_internal/ms_pathname_expansion_wildcard.c
+++ b/src/execution/expantion/ms_pathname_expantion_internal/ms_pathname_expansion_wildcard.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ms_pathname_expansion_wildcard.c                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rnakatan <rnakatan@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/14 03:33:17 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/03/15 08:00:32 by rnakatan         ###   ########.fr       */
+/*   Updated: 2025/04/06 11:43:23 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,8 @@ char	**ms_pathname_expansion_wildcard(char *dir_name, char *token)
 	char	**expanded_path_list;
 
 	file_list = ms_get_file_list_from_dir(dir_name);
+	if (file_list == NULL)
+		return (NULL);
 	index = 0;
 	while (token[index] != '\0')
 	{

--- a/src/execution/expantion/ms_pathname_expantion_internal/ms_pathname_expansion_wildcard.c
+++ b/src/execution/expantion/ms_pathname_expantion_internal/ms_pathname_expansion_wildcard.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/14 03:33:17 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/04/06 11:43:23 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/06 11:55:13 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@ char	**ms_pathname_expansion_wildcard(char *dir_name, char *token)
 
 	file_list = ms_get_file_list_from_dir(dir_name);
 	if (file_list == NULL)
-		return (NULL);
+		return (ft_calloc(1, sizeof(char *)));
 	index = 0;
 	while (token[index] != '\0')
 	{

--- a/tests/pytest/expansion/pathname_expansion/test_double_wildcard.sh
+++ b/tests/pytest/expansion/pathname_expansion/test_double_wildcard.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# テスト用の設定の読み込み
+cd "$(dirname $0)"
+
+# テスト
+. "module/create_testdir.sh"
+cd testdir
+$LEAKCHECK $PROG << "EOF"
+echo */*
+EOF
+cd ../

--- a/tests/pytest/expansion/pathname_expansion/test_double_wildcard.sh
+++ b/tests/pytest/expansion/pathname_expansion/test_double_wildcard.sh
@@ -3,8 +3,9 @@
 # テスト用の設定の読み込み
 cd "$(dirname $0)"
 
+. "../../test_prepare.sh"
+
 # テスト
-. "module/create_testdir.sh"
 cd testdir
 $LEAKCHECK $PROG << "EOF"
 echo */*

--- a/tests/pytest/expansion/pathname_expansion/test_double_wildcard.sh
+++ b/tests/pytest/expansion/pathname_expansion/test_double_wildcard.sh
@@ -6,8 +6,6 @@ cd "$(dirname $0)"
 . "../../test_prepare.sh"
 
 # テスト
-cd testdir
 $LEAKCHECK $PROG << "EOF"
 echo */*
 EOF
-cd ../

--- a/tests/pytest/expansion/pathname_expansion/test_pathname_expansion.py
+++ b/tests/pytest/expansion/pathname_expansion/test_pathname_expansion.py
@@ -25,3 +25,9 @@ def test_include_nothing():
 		expected_stdout = result,
 		expected_stderr = ""
 	)
+
+def test_double():
+	script_tester.test(dirname + "test_double_wildcard.sh",
+		expected_stdout = "",
+		expected_stderr = ""
+	)

--- a/tests/pytest/expansion/pathname_expansion/test_pathname_expansion.py
+++ b/tests/pytest/expansion/pathname_expansion/test_pathname_expansion.py
@@ -27,7 +27,8 @@ def test_include_nothing():
 	)
 
 def test_double():
+	result = "*/*\n"
 	script_tester.test(dirname + "test_double_wildcard.sh",
-		expected_stdout = "",
+		expected_stdout = result,
 		expected_stderr = ""
 	)


### PR DESCRIPTION
```
echo */*
```
のように入力するとクラッシュするのを修正しました。
ft_calloc(1, sizeof(char *))としていますが、`NULL`としていないのは、`NULL`を返すと別の部分でリークが発生して大変なのでこのようなカタチで修正しています。