### PR TITLE
228-add-suppファイルに下記内容の追加 

### DIFF
--- a/src/.supp
+++ b/src/.supp
@@ -18,6 +18,14 @@
 }
 
 {
+   exclude_readline_library
+   Memcheck:Leak
+   match-leak-kinds: all
+   ...
+   fun:replace_history_entry
+}
+
+{
    usr_bin_leak
    Memcheck:Leak
    match-leak-kinds: all


### PR DESCRIPTION

suppressionルールに、replace_history_entryを除外するルールを追加しました。
