### PR TITLE
225 bug exit の too many argumentsではexitしない

### DIFF
--- a/src/builtins/exit/exit_internal_type.h
+++ b/src/builtins/exit/exit_internal_type.h
@@ -6,16 +6,19 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/01 09:36:37 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/02/01 09:56:55 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/06 12:29:25 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef EXIT_INTERNAL_TYPE_H
 # define EXIT_INTERNAL_TYPE_H
 
+# include <stdbool.h>
+
 typedef struct s_builtin_exit
 {
-	int	exit_status;
+	int		exit_status;
+	bool	is_exit;
 }	t_builtin_exit;
 
 #endif

--- a/src/builtins/exit/ms_builtin_exit.c
+++ b/src/builtins/exit/ms_builtin_exit.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/01 15:10:41 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/04/05 13:44:58 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/06 12:30:35 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,8 +26,12 @@ int	ms_builtin_exit(
 
 	(void)path;
 	(void)envp;
+	parsed.exit_status = 0;
+	parsed.is_exit = true;
 	status = ms_parse_builtin_exit(&parsed, argv);
-	if (status != 0)
+	if (parsed.is_exit == false)
+		status = 1;
+	else if (status != 0)
 		status = ms_add_meta(status, IS_EXIT);
 	else
 		status = ms_add_meta(parsed.exit_status, IS_EXIT);

--- a/src/builtins/exit/ms_parse_builtin_exit.c
+++ b/src/builtins/exit/ms_parse_builtin_exit.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/01 09:37:20 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/03/05 13:24:51 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/06 12:30:00 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,8 +28,7 @@ int	ms_parse_builtin_exit(t_builtin_exit *parsed, char *const argv[])
 	char		*str;
 
 	idx = 1;
-	if (argv[idx] != NULL
-		&& ft_strcmp(argv[idx], "--") == 0)
+	if (argv[idx] != NULL && ft_strcmp(argv[idx], "--") == 0)
 		idx++;
 	if (argv[idx] == NULL)
 		str = ms_getenv("?");
@@ -39,12 +38,13 @@ int	ms_parse_builtin_exit(t_builtin_exit *parsed, char *const argv[])
 		return (ms_perror_cmd("exit", "not set `?' variable"), 1);
 	errno = 0;
 	status = ft_strtol(str, &endptr, 10);
-	if (ms_is_numeric(str, endptr) == false
-		|| errno != 0)
-		return (ms_perror_cmd2("exit",
-				str, "numeric argument required"), 2);
+	if (ms_is_numeric(str, endptr) == false || errno != 0)
+		return (ms_perror_cmd2("exit", str, "numeric argument required"), 2);
 	if (ms_ntpsize((void **)(argv + idx)) > 1)
+	{
+		parsed->is_exit = false;
 		return (ms_perror_cmd("exit", "too many arguments"), 1);
+	}
 	parsed->exit_status = status;
 	return (0);
 }

--- a/tests/pytest/builtin/exit/test_exit_errors/test_exit_errors.py
+++ b/tests/pytest/builtin/exit/test_exit_errors/test_exit_errors.py
@@ -13,3 +13,8 @@ def	test_numeric_argument_required():
 	script_tester.test(testdir + "test_numeric_argument_required.sh",
         expected_stdout = "2\n",
         expected_stderr = "minishell: exit: a: numeric argument required\n")
+
+def	test_exit_too_many_argument():
+	script_tester.test(testdir + "test_exit_too_many_argument.sh",
+        expected_stdout = "1\n",
+        expected_stderr = "minishell: exit: too many arguments\n")

--- a/tests/pytest/builtin/exit/test_exit_errors/test_exit_too_many_argument.sh
+++ b/tests/pytest/builtin/exit/test_exit_errors/test_exit_too_many_argument.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# テスト用の設定の読み込み
+cd "$(dirname $0)"
+. "../../../test_prepare.sh"
+
+# テスト
+$LEAKCHECK $PROG << "EOF"
+exit 1 2
+echo $?
+EOF


### PR DESCRIPTION

`exit 1 2`や`exit 1 a`のように引数が多いときにはexitしないように修正しました。
このときの終了ステータスは、`1`を設定しています。

また、テストを追加しました。
