### PR TITLE
237 bug unset時にexportの一覧からも削除する

### DIFF
--- a/src/builtins/unset/ms_builtin_unset.c
+++ b/src/builtins/unset/ms_builtin_unset.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/30 18:16:25 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/02/02 07:26:04 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/06 12:56:42 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,6 +39,7 @@ int	ms_builtin_unset(const char *path, char *const argv[], char *const envp[])
 	while (parsed.names[index] != NULL)
 	{
 		ms_unsetenv(parsed.names[index]);
+		ms_remove_export(parsed.names[index]);
 		index++;
 	}
 	return (0);

--- a/src/include/libms.h
+++ b/src/include/libms.h
@@ -103,6 +103,7 @@ t_list			*ms_get_exports(void);
 void			ms_set_exports(t_list *exports);
 void			ms_clear_exports(void);
 int				ms_add_export(const char *name);
+int				ms_remove_export(const char *name);
 t_list			*ms_find_export(const char *name);
 
 // mnsh_subshell

--- a/src/libms/ms_remove_export.c
+++ b/src/libms/ms_remove_export.c
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_remove_export.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/06 12:50:17 by tookuyam          #+#    #+#             */
+/*   Updated: 2025/04/06 12:56:22 by tookuyam         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libms.h"
+#include "libft.h"
+#include <stdlib.h>
+
+/**
+ * @brief Remove an export variable.
+ * @param name The name of the export variable.
+ * @return 0 on success.
+ */
+int	ms_remove_export(const char *name)
+{
+	t_list	*env_list;
+	t_list	*target_lst;
+
+	target_lst = ms_find_export(name);
+	if (target_lst == NULL)
+		return (1);
+	env_list = ms_get_exports();
+	ft_lstdel_content(&env_list, target_lst->content, free);
+	ms_set_exports(env_list);
+	return (0);
+}

--- a/tests/googletest/builtins/unset/test_ms_builtin_unset.cpp
+++ b/tests/googletest/builtins/unset/test_ms_builtin_unset.cpp
@@ -83,3 +83,20 @@ TEST(ms_builtin_unset, error_if_use_invalid_option)
     EXPECT_EQ(term.getStdout(), expectStdout);
     EXPECT_EQ(term.getStderr(), expectStderr);
 }
+
+/** exportの方もunsetする */
+TEST(ms_builtin_unset, unset_export_environ)
+{
+	IoTerminal 	term;
+	const char 	*args[] = {"unset", "HOGE", NULL};
+	t_list		*export_env;
+
+	ms_setenv("HOGE", "\\\"", 1);
+
+	term.boot();
+	ms_builtin_unset(NULL, (char *const *)args, NULL);
+	term.exit();
+
+	export_env = ms_find_export("HOGE");
+	EXPECT_EQ(export_env, nullptr);
+}


### PR DESCRIPTION

unset時にexportの一覧からも削除する実装と、テストを作成しました。

以下のようなコマンドを実行すると、ZOGEがexportとして表示されないように修正しました。
```
export ZOGE=123
unset ZOGE
export
```