### PR TITLE
238-cat-ctrlcで終了ステータスが230になっている 

### DIFF
--- a/src/input/ms_input.c
+++ b/src/input/ms_input.c
@@ -48,13 +48,13 @@ static int	ms_run_command(char *line)
 	int		ret;
 
 	ret = 0;
-	if (! g_rl_is_sigint)
+	if (g_rl_is_sigint)
+		ms_set_exit_status(128 + SIGINT);
+	else
 	{
 		ms_add_mnsh_history(line);
 		ret = ms_execution(line);
 	}
-	if (g_rl_is_sigint)
-		ms_set_exit_status(ret);
 	return (ret);
 }
 

--- a/src/libms/ms_set_exit_status.c
+++ b/src/libms/ms_set_exit_status.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/29 12:14:43 by rnakatan          #+#    #+#             */
-/*   Updated: 2025/04/01 08:57:49 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/06 13:08:12 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,8 +27,6 @@ int	ms_set_exit_status(int ret)
 	int		status;
 
 	status = ms_get_status_from_meta(ret);
-	if (g_rl_is_sigint)
-		status += 128 + SIGINT;
 	stat_str = ft_itoa(status);
 	ms_setenv("?", stat_str, 1);
 	free(stat_str);


### PR DESCRIPTION

cat -> ctrl+cで終了ステータスが230になってしまうバグを修正しました。

テストは追加していませんが以下のようなコマンドを使ってテストしました。
```sh
minishell $ cat | ls
fileA
^C    
minishell $ echo $?
0
minishell $ cat
^C
minishell $ echo $?
130
minishell $ echo $?
0
minishell $ ^C
minishell $ echo $?
130
minishell $ ^C
minishell $ 
minishell $ 
minishell $ 
minishell $ 
minishell $ echo $?
130
minishell $
```