### PR TITLE
244-vshellでカレントディレクトリを変更するとsuppファイルの参照に失敗する 

### DIFF
--- a/src/vshell
+++ b/src/vshell
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+SRC_DIR=$(cd $(dirname "$0") ; pwd)
+
 valgrind \
 	-q \
 	--leak-check=full \
 	--show-leak-kinds=all \
-	--suppressions=.supp \
+	--suppressions="$SRC_DIR"/.supp \
 	--track-origins=yes \
 	--trace-children=yes \
 	--error-exitcode=230 \


### PR DESCRIPTION

絶対パスで指定することで、エラーが発生しないようにしました！