### PR TITLE
 257-bug-ft_printfのwriteが失敗したときにメモリリークする

### DIFF
--- a/src/builtins/cd/ms_builtin_cd.c
+++ b/src/builtins/cd/ms_builtin_cd.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/01 06:29:14 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/04/07 11:38:28 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/09 05:19:43 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,6 @@
 #include "libft.h"
 #include "libms.h"
 #include "ms_error.h"
-#include "ft_printf.h"
 #include <stddef.h>
 #include <errno.h>
 #include <string.h>
@@ -54,7 +53,7 @@ static int	ms_builtin_cd2(t_builtin_cd *parsed)
 	if (chdir(resolved_path) == -1)
 		return (ms_perror_cd(resolved_path), free(resolved_path), 1);
 	if (parsed->is_to_oldpwd)
-		ft_printf("%s\n", resolved_path);
+		printf("%s\n", resolved_path);
 	result = ms_setnewpwd(parsed, resolved_path);
 	free(resolved_path);
 	return (result);

--- a/src/builtins/env-command/ms_builtin_env.c
+++ b/src/builtins/env-command/ms_builtin_env.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/30 19:31:02 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/04/07 12:01:47 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/09 05:19:48 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,6 @@
 #include "libms.h"
 #include "ms_getopt.h"
 #include "builtin_internal.h"
-#include "ft_printf.h"
 #include <stddef.h>
 #include <stdio.h>
 
@@ -74,7 +73,7 @@ static void	ms_print_environ(void)
 	{
 		value = ms_getenv(*names);
 		if (value != NULL)
-			ft_printf("%s=%s\n", *names, value);
+			printf("%s=%s\n", *names, value);
 		names++;
 	}
 	ms_destroy_ntp(head);

--- a/src/builtins/export/ms_export_print_command.c
+++ b/src/builtins/export/ms_export_print_command.c
@@ -14,7 +14,6 @@
 #include "libms_internal.h"
 #include "export_internal.h"
 #include "libft.h"
-#include "ft_printf.h"
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -54,11 +53,11 @@ static void	ms_print_export_environs(char *const envp[])
 		envname = *envitr;
 		envvalue = ms_getenv(envname);
 		if (envvalue == NULL)
-			ft_printf("declare -x %s\n", envname);
+			printf("declare -x %s\n", envname);
 		else
 		{
 			escaped_value = ms_escape_export_value(envvalue);
-			ft_printf("declare -x %s=\"%s\"\n", envname, escaped_value);
+			printf("declare -x %s=\"%s\"\n", envname, escaped_value);
 			free(escaped_value);
 		}
 		envitr++;

--- a/src/builtins/pwd/ms_builtin_pwd.c
+++ b/src/builtins/pwd/ms_builtin_pwd.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/30 13:53:39 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/04/07 11:41:23 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/09 05:22:36 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,6 @@
 #include "libft.h"
 #include "libms.h"
 #include "ms_getopt.h"
-#include "ft_printf.h"
 #include <stdlib.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -46,7 +45,7 @@ int	ms_builtin_pwd(
 			cwd = ft_strdup(cwd);
 	}
 	if (cwd != NULL)
-		ft_printf("%s\n", cwd);
+		printf("%s\n", cwd);
 	free(cwd);
 	return (0);
 }

--- a/src/finalize/ms_cleanup_and_exit.c
+++ b/src/finalize/ms_cleanup_and_exit.c
@@ -6,7 +6,7 @@
 /*   By: tookuyam <tookuyam@student.42tokyo.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/15 13:46:44 by tookuyam          #+#    #+#             */
-/*   Updated: 2025/04/05 14:00:12 by tookuyam         ###   ########.fr       */
+/*   Updated: 2025/04/09 05:23:09 by tookuyam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,6 @@
 #include <stdio.h>
 
 static void	ms_export_history(void);
-static void	ms_clear_filedescriptors(void);
 
 void	ms_cleanup_and_exit(int status)
 {
@@ -34,7 +33,6 @@ void	ms_cleanup_and_exit(int status)
 	ms_clear_cdwd();
 	ms_clear_environ(NULL);
 	ms_clear_exports();
-	ms_clear_filedescriptors();
 	exit(ms_get_status_from_meta(status));
 }
 
@@ -55,11 +53,4 @@ static void	ms_export_history(void)
 	if (*endptr != '\0' || histfilesize < 0)
 		return ;
 	ms_history_truncate_file(ms_getenv("HISTFILE"), histfilesize);
-}
-
-static void	ms_clear_filedescriptors(void)
-{
-	close(0);
-	close(1);
-	close(2);
 }

--- a/src/vshell
+++ b/src/vshell
@@ -8,6 +8,6 @@ valgrind \
 	--track-origins=yes \
 	--trace-children=yes \
 	--error-exitcode=230 \
-	--track-fds=all \
+	--track-fds=yes \
 	./minishell
 	# --gen-suppressions=yes \


### PR DESCRIPTION

すでに閉じられたパイプに出力しようとすることで、SIGPIPEを受け取ってしまい、強制終了ー＞リーク。
となっていたみたいです。

出力されない問題もあったのですが、それは、ファイルディスクリプタ0, 1, 2を閉じているのが原因のようでした。

つまり、プログラム終了時にprintfのバッファが標準出力に出力するのですが、既にファイルディスクリプタが閉じられているため、表示されなかった。という感じみたいです。

ファイルディスクリプタ0, 1, 2を閉じないままにすると、valgrindでエラーが出るのですが、`--check-fds=yes`とすることで、0, 1, 2のみを除いてファイルディスクリプタチェックできるようなのでその部分も修正しました。